### PR TITLE
4615: Bump bcl to bring in new auth provider and fake auth provider versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4003,9 +4003,9 @@
       }
     },
     "buying-catalogue-library": {
-      "version": "1.0.23",
-      "resolved": "https://registry.npmjs.org/buying-catalogue-library/-/buying-catalogue-library-1.0.23.tgz",
-      "integrity": "sha512-uZGK8YloWsz2X5075TKBCXD7IWAtq5LxKnzchc7s89sULruHBXcKEXI+Mecto2/UeqlmpNl+4oGXhM/n6Nx3lA==",
+      "version": "1.0.24",
+      "resolved": "https://registry.npmjs.org/buying-catalogue-library/-/buying-catalogue-library-1.0.24.tgz",
+      "integrity": "sha512-XRJWcp8j1hxnLXXa7HLlQkMPsvI3BLxAwGHemaL2nfhsDweBD3BGFLZbxsFv42f+J04rn8Hgg20FmNzHW7CS4w==",
       "requires": {
         "@babel/cli": "^7.8.4",
         "@babel/core": "^7.9.0",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "axios": "^0.19.0",
     "body-parser": "^1.19.0",
     "buying-catalogue-components": "^1.1.70",
-    "buying-catalogue-library": "^1.0.23",
+    "buying-catalogue-library": "^1.0.24",
     "compression": "^1.7.4",
     "cookie-parser": "^1.4.5",
     "csurf": "^1.11.0",


### PR DESCRIPTION
[AB#4615](https://buyingcatalog.visualstudio.com/c5f97979-5b03-4d10-ba8d-871d0526b408/_workitems/edit/4615)