### PR TITLE
Feature/4840 show suppliers returned

### DIFF
--- a/app/endpoints.js
+++ b/app/endpoints.js
@@ -10,7 +10,7 @@ const endpoints = {
   getDescription: options => `${orderApiUrl}/api/v1/orders/${options.orderId}/sections/description`,
   getCallOffOrderingParty: options => `${orderApiUrl}/api/v1/orders/${options.orderId}/sections/ordering-party`,
   getOrganisationById: options => `${organisationApiUrl}/api/v1/Organisations/${options.orgId}`,
-  getSearchSuppliers: options => `${solutionsApiUrl}/api/v1/suppliers?name=${options.supplierNameToFind}`,
+  getSearchSuppliers: options => `${solutionsApiUrl}/api/v1/suppliers?name=${options.name}`,
   // PUT endpoints
   putDescription: options => `${orderApiUrl}/api/v1/orders/${options.orderId}/sections/description`,
   putOrderingParty: options => `${orderApiUrl}/api/v1/orders/${options.orderId}/sections/ordering-party`,

--- a/app/pages/sections/supplier/search/contextCreator.js
+++ b/app/pages/sections/supplier/search/contextCreator.js
@@ -2,14 +2,11 @@ import { formatErrors, formatAllErrors, addErrorsAndDataToManifest } from 'buyin
 import manifest from './manifest.json';
 import { baseUrl } from '../../../../config';
 
-export const getContext = ({ orderId }) => {
-  const context = ({
-    ...manifest,
-    title: `${manifest.title} ${orderId}`,
-    backLinkHref: `${baseUrl}/organisation/${orderId}`,
-  });
-  return context;
-};
+export const getContext = ({ orderId }) => ({
+  ...manifest,
+  title: `${manifest.title} ${orderId}`,
+  backLinkHref: `${baseUrl}/organisation/${orderId}`,
+});
 
 export const getErrorContext = ({ orderId, validationErrors, data }) => {
   const formattedErrors = formatErrors({ manifest, errors: validationErrors });

--- a/app/pages/sections/supplier/search/contextCreator.test.js
+++ b/app/pages/sections/supplier/search/contextCreator.test.js
@@ -6,7 +6,7 @@ import { baseUrl } from '../../../../config';
 jest.mock('buying-catalogue-library');
 
 
-describe('decription contextCreator', () => {
+describe('supplier search contextCreator', () => {
   describe('getContext', () => {
     it('should return the backLinkText', () => {
       const context = getContext({ orderId: 'order-1' });

--- a/app/pages/sections/supplier/search/controller.js
+++ b/app/pages/sections/supplier/search/controller.js
@@ -1,7 +1,4 @@
-import { getData } from 'buying-catalogue-library';
-import { getEndpoint } from '../../../../endpoints';
 import { getContext, getErrorContext } from './contextCreator';
-import { logger } from '../../../../logger';
 
 export const getSupplierSearchPageContext = async ({ orderId }) => (
   getContext({ orderId })
@@ -22,11 +19,3 @@ export const validateSupplierSearchForm = ({ data }) => {
 };
 
 export const getSupplierSearchPageErrorContext = params => getErrorContext(params);
-
-export const findSuppliers = async ({ supplierNameToFind, accessToken }) => {
-  const endpoint = getEndpoint({ endpointLocator: 'getSearchSuppliers', options: { supplierNameToFind } });
-  const suppliersFound = await getData({ endpoint, accessToken, logger });
-  logger.info(`Searching for "${supplierNameToFind}" returned ${suppliersFound.length} supplier`);
-
-  return suppliersFound;
-};

--- a/app/pages/sections/supplier/search/controller.js
+++ b/app/pages/sections/supplier/search/controller.js
@@ -26,7 +26,6 @@ export const getSupplierSearchPageErrorContext = params => getErrorContext(param
 export const findSuppliers = async ({ supplierNameToFind, accessToken }) => {
   const endpoint = getEndpoint({ endpointLocator: 'getSearchSuppliers', options: { supplierNameToFind } });
   const suppliersFound = await getData({ endpoint, accessToken, logger });
-
   logger.info(`Searching for "${supplierNameToFind}" returned ${suppliersFound.length} supplier`);
 
   return suppliersFound;

--- a/app/pages/sections/supplier/search/controller.test.js
+++ b/app/pages/sections/supplier/search/controller.test.js
@@ -1,6 +1,6 @@
 import { getData } from 'buying-catalogue-library';
 import * as contextCreator from './contextCreator';
-import { getSupplierSearchPageContext, validateSupplierSearchForm, findSuppliers } from './controller';
+import { getSupplierSearchPageContext, validateSupplierSearchForm } from './controller';
 import { solutionsApiUrl } from '../../../../config';
 import { logger } from '../../../../logger';
 
@@ -71,25 +71,6 @@ describe('supplier search controller', () => {
         const response = validateSupplierSearchForm({ data });
 
         expect(response.errors).toEqual(expectedValidationErrors);
-      });
-    });
-  });
-
-  describe('findSuppliers', () => {
-    afterEach(() => {
-      getData.mockReset();
-    });
-
-    it('should call getData once with the correct params', async () => {
-      getData
-        .mockResolvedValueOnce({ data: [] });
-
-      await findSuppliers({ supplierNameToFind: 'some-supp', accessToken: 'access_token' });
-      expect(getData.mock.calls.length).toEqual(1);
-      expect(getData).toHaveBeenCalledWith({
-        endpoint: `${solutionsApiUrl}/api/v1/suppliers?name=some-supp`,
-        accessToken: 'access_token',
-        logger,
       });
     });
   });

--- a/app/pages/sections/supplier/search/controller.test.js
+++ b/app/pages/sections/supplier/search/controller.test.js
@@ -1,8 +1,5 @@
-import { getData } from 'buying-catalogue-library';
 import * as contextCreator from './contextCreator';
 import { getSupplierSearchPageContext, validateSupplierSearchForm } from './controller';
-import { solutionsApiUrl } from '../../../../config';
-import { logger } from '../../../../logger';
 
 jest.mock('buying-catalogue-library');
 

--- a/app/pages/sections/supplier/search/ui.test.js
+++ b/app/pages/sections/supplier/search/ui.test.js
@@ -98,7 +98,7 @@ test('should render a supplierName question as a textfield', async (t) => {
     .expect(supplierNameInput.find('input').count).eql(1);
 });
 
-test('should render Search button', async (t) => {
+test('should render the Search button', async (t) => {
   await pageSetup(t, true);
   await t.navigateTo(pageUrl);
 

--- a/app/pages/sections/supplier/search/ui.test.js
+++ b/app/pages/sections/supplier/search/ui.test.js
@@ -2,7 +2,6 @@ import nock from 'nock';
 import { ClientFunction, Selector } from 'testcafe';
 import { extractInnerText } from 'buying-catalogue-library';
 import content from './manifest.json';
-import { solutionsApiUrl } from '../../../../config';
 
 const pageUrl = 'http://localhost:1234/organisation/order-1/supplier/search';
 
@@ -160,33 +159,4 @@ test('should anchor to the field when clicking on the error link in errorSummary
 
     .click(errorSummary.find('li a').nth(0))
     .expect(getLocation()).eql(`${pageUrl}#supplierName`);
-});
-
-test('should show the error page if no suppliers are returned', async (t) => {
-  nock(solutionsApiUrl)
-    .get('/api/v1/suppliers?name=some-supp')
-    .reply(200, []);
-
-  await pageSetup(t, true);
-  await t.navigateTo(pageUrl);
-
-  const supplierNameInput = Selector('[data-test-id="question-supplierName"]');
-  const searchButton = Selector('[data-test-id="search-button"] button');
-
-  const backLink = Selector('[data-test-id="error-back-link"]');
-  const errorTitle = Selector('[data-test-id="error-title"]');
-  const errorDescription = Selector('[data-test-id="error-description"]');
-
-  await t
-    .typeText(supplierNameInput.find('input'), 'some-supp')
-    .click(searchButton);
-
-  await t
-    .expect(backLink.exists).ok()
-    .expect(await extractInnerText(backLink)).eql('Go back to search')
-    .expect(backLink.find('a').getAttribute('href')).ok('/order/organisations/order-1/supplier/search')
-    .expect(errorTitle.exists).ok()
-    .expect(await extractInnerText(errorTitle)).eql('No Supplier found')
-    .expect(errorDescription.exists).ok()
-    .expect(await extractInnerText(errorDescription)).eql("There are no suppliers that match the search terms you've provided. Try searching again.");
 });

--- a/app/pages/sections/supplier/select/contextCreator.js
+++ b/app/pages/sections/supplier/select/contextCreator.js
@@ -1,9 +1,28 @@
 import manifest from './manifest.json';
 import { baseUrl } from '../../../../config';
 
-export const getContext = ({ orderId }) => {
+const generateSupplierOptions = ({ suppliers }) => {
+  const supplierOptions = suppliers.map(supplier => ({
+    value: supplier.supplierId,
+    text: supplier.name,
+  }));
+
+  return supplierOptions;
+};
+
+const generateQuestionsContext = ({ suppliers }) => {
+  const questions = manifest.questions.map(question => ({
+    ...question,
+    options: generateSupplierOptions({ suppliers }),
+  }));
+
+  return questions;
+};
+
+export const getContext = ({ orderId, suppliers }) => {
   const context = ({
     ...manifest,
+    questions: suppliers && generateQuestionsContext({ suppliers }),
     backLinkHref: `${baseUrl}/organisation/${orderId}/supplier/search`,
   });
   return context;

--- a/app/pages/sections/supplier/select/contextCreator.js
+++ b/app/pages/sections/supplier/select/contextCreator.js
@@ -1,29 +1,22 @@
 import manifest from './manifest.json';
 import { baseUrl } from '../../../../config';
 
-const generateSupplierOptions = ({ suppliers }) => {
-  const supplierOptions = suppliers.map(supplier => ({
+const generateSupplierOptions = ({ suppliers }) => (
+  suppliers.map(supplier => ({
     value: supplier.supplierId,
     text: supplier.name,
-  }));
+  }))
+);
 
-  return supplierOptions;
-};
-
-const generateQuestionsContext = ({ suppliers }) => {
-  const questions = manifest.questions.map(question => ({
+const generateQuestionsContext = ({ suppliers }) => (
+  manifest.questions.map(question => ({
     ...question,
     options: generateSupplierOptions({ suppliers }),
-  }));
+  }))
+);
 
-  return questions;
-};
-
-export const getContext = ({ orderId, suppliers }) => {
-  const context = ({
-    ...manifest,
-    questions: suppliers && generateQuestionsContext({ suppliers }),
-    backLinkHref: `${baseUrl}/organisation/${orderId}/supplier/search`,
-  });
-  return context;
-};
+export const getContext = ({ orderId, suppliers }) => ({
+  ...manifest,
+  questions: suppliers && generateQuestionsContext({ suppliers }),
+  backLinkHref: `${baseUrl}/organisation/${orderId}/supplier/search`,
+});

--- a/app/pages/sections/supplier/select/contextCreator.js
+++ b/app/pages/sections/supplier/select/contextCreator.js
@@ -1,0 +1,10 @@
+import manifest from './manifest.json';
+import { baseUrl } from '../../../../config';
+
+export const getContext = ({ orderId }) => {
+  const context = ({
+    ...manifest,
+    backLinkHref: `${baseUrl}/organisation/${orderId}/supplier/search`,
+  });
+  return context;
+};

--- a/app/pages/sections/supplier/select/contextCreator.test.js
+++ b/app/pages/sections/supplier/select/contextCreator.test.js
@@ -1,0 +1,36 @@
+import manifest from './manifest.json';
+import { getContext } from './contextCreator';
+import { baseUrl } from '../../../../config';
+
+jest.mock('buying-catalogue-library');
+
+
+describe('supplier select contextCreator', () => {
+  describe('getContext', () => {
+    it('should return the backLinkText', () => {
+      const context = getContext({ orderId: 'order-1' });
+      expect(context.backLinkText).toEqual(manifest.backLinkText);
+    });
+
+    it('should construct the backLinkHref', () => {
+      const orderId = 'order-id';
+      const context = getContext({ orderId });
+      expect(context.backLinkHref).toEqual(`${baseUrl}/organisation/${orderId}/supplier/search`);
+    });
+
+    it('should return the title', () => {
+      const context = getContext({});
+      expect(context.title).toEqual(manifest.title);
+    });
+
+    it('should return the description', () => {
+      const context = getContext({});
+      expect(context.description).toEqual(manifest.description);
+    });
+
+    it('should return the continueButtonText', () => {
+      const context = getContext({});
+      expect(context.continueButtonText).toEqual(manifest.continueButtonText);
+    });
+  });
+});

--- a/app/pages/sections/supplier/select/contextCreator.test.js
+++ b/app/pages/sections/supplier/select/contextCreator.test.js
@@ -28,6 +28,42 @@ describe('supplier select contextCreator', () => {
       expect(context.description).toEqual(manifest.description);
     });
 
+    it('should return the select supplier question', () => {
+      const expectedContext = {
+        questions: [
+          {
+            id: 'selectSupplier',
+            mainAdvice: 'Select Supplier',
+            options: [
+              {
+                value: 'supplier-1',
+                text: 'Supplier 1',
+              },
+              {
+                value: 'supplier-2',
+                text: 'Supplier 2',
+              },
+            ],
+          },
+        ],
+      };
+
+      const suppliers = [
+        {
+          supplierId: 'supplier-1',
+          name: 'Supplier 1',
+        },
+        {
+          supplierId: 'supplier-2',
+          name: 'Supplier 2',
+        },
+      ];
+
+      const context = getContext({ suppliers });
+      expect(context.questions).toEqual(expectedContext.questions);
+    });
+
+
     it('should return the continueButtonText', () => {
       const context = getContext({});
       expect(context.continueButtonText).toEqual(manifest.continueButtonText);

--- a/app/pages/sections/supplier/select/controller.js
+++ b/app/pages/sections/supplier/select/controller.js
@@ -11,6 +11,4 @@ export const findSuppliers = async ({ supplierNameToFind, accessToken }) => {
   return suppliersFound;
 };
 
-export const getSupplierSelectPageContext = ({ orderId, suppliers }) => (
-  getContext({ orderId, suppliers })
-);
+export const getSupplierSelectPageContext = params => getContext(params);

--- a/app/pages/sections/supplier/select/controller.js
+++ b/app/pages/sections/supplier/select/controller.js
@@ -1,6 +1,7 @@
 import { getData } from 'buying-catalogue-library';
 import { getEndpoint } from '../../../../endpoints';
 import { logger } from '../../../../logger';
+import { getContext } from './contextCreator';
 
 export const findSuppliers = async ({ supplierNameToFind, accessToken }) => {
   const endpoint = getEndpoint({ endpointLocator: 'getSearchSuppliers', options: { supplierNameToFind } });
@@ -9,3 +10,7 @@ export const findSuppliers = async ({ supplierNameToFind, accessToken }) => {
 
   return suppliersFound;
 };
+
+export const getSupplierSelectPageContext = ({ orderId }) => (
+  getContext({ orderId })
+);

--- a/app/pages/sections/supplier/select/controller.js
+++ b/app/pages/sections/supplier/select/controller.js
@@ -3,10 +3,10 @@ import { getEndpoint } from '../../../../endpoints';
 import { logger } from '../../../../logger';
 import { getContext } from './contextCreator';
 
-export const findSuppliers = async ({ supplierNameToFind, accessToken }) => {
-  const endpoint = getEndpoint({ endpointLocator: 'getSearchSuppliers', options: { supplierNameToFind } });
+export const findSuppliers = async ({ name, accessToken }) => {
+  const endpoint = getEndpoint({ endpointLocator: 'getSearchSuppliers', options: { name } });
   const suppliersFound = await getData({ endpoint, accessToken, logger });
-  logger.info(`Searching for "${supplierNameToFind}" returned ${suppliersFound.length} supplier`);
+  logger.info(`Searching for "${name}" returned ${suppliersFound.length} supplier`);
 
   return suppliersFound;
 };

--- a/app/pages/sections/supplier/select/controller.js
+++ b/app/pages/sections/supplier/select/controller.js
@@ -1,0 +1,11 @@
+import { getData } from 'buying-catalogue-library';
+import { getEndpoint } from '../../../../endpoints';
+import { logger } from '../../../../logger';
+
+export const findSuppliers = async ({ supplierNameToFind, accessToken }) => {
+  const endpoint = getEndpoint({ endpointLocator: 'getSearchSuppliers', options: { supplierNameToFind } });
+  const suppliersFound = await getData({ endpoint, accessToken, logger });
+  logger.info(`Searching for "${supplierNameToFind}" returned ${suppliersFound.length} supplier`);
+
+  return suppliersFound;
+};

--- a/app/pages/sections/supplier/select/controller.js
+++ b/app/pages/sections/supplier/select/controller.js
@@ -11,6 +11,6 @@ export const findSuppliers = async ({ supplierNameToFind, accessToken }) => {
   return suppliersFound;
 };
 
-export const getSupplierSelectPageContext = ({ orderId }) => (
-  getContext({ orderId })
+export const getSupplierSelectPageContext = ({ orderId, suppliers }) => (
+  getContext({ orderId, suppliers })
 );

--- a/app/pages/sections/supplier/select/controller.test.js
+++ b/app/pages/sections/supplier/select/controller.test.js
@@ -1,9 +1,14 @@
 import { getData } from 'buying-catalogue-library';
-import { findSuppliers } from './controller';
+import { findSuppliers, getSupplierSelectPageContext } from './controller';
 import { solutionsApiUrl } from '../../../../config';
 import { logger } from '../../../../logger';
+import * as contextCreator from './contextCreator';
 
 jest.mock('buying-catalogue-library');
+
+jest.mock('./contextCreator', () => ({
+  getContext: jest.fn(),
+}));
 
 describe('supplier select controller', () => {
   describe('findSuppliers', () => {
@@ -22,6 +27,18 @@ describe('supplier select controller', () => {
         accessToken: 'access_token',
         logger,
       });
+    });
+  });
+
+  describe('getSupplierSelectPageContext', () => {
+    it('should call getContext with the correct params', async () => {
+      contextCreator.getContext
+        .mockResolvedValueOnce();
+
+      await getSupplierSelectPageContext({ orderId: 'order-1' });
+
+      expect(contextCreator.getContext.mock.calls.length).toEqual(1);
+      expect(contextCreator.getContext).toHaveBeenCalledWith({ orderId: 'order-1' });
     });
   });
 });

--- a/app/pages/sections/supplier/select/controller.test.js
+++ b/app/pages/sections/supplier/select/controller.test.js
@@ -1,0 +1,27 @@
+import { getData } from 'buying-catalogue-library';
+import { findSuppliers } from './controller';
+import { solutionsApiUrl } from '../../../../config';
+import { logger } from '../../../../logger';
+
+jest.mock('buying-catalogue-library');
+
+describe('supplier select controller', () => {
+  describe('findSuppliers', () => {
+    afterEach(() => {
+      getData.mockReset();
+    });
+
+    it('should call getData once with the correct params', async () => {
+      getData
+        .mockResolvedValueOnce({ data: [] });
+
+      await findSuppliers({ supplierNameToFind: 'some-supp', accessToken: 'access_token' });
+      expect(getData.mock.calls.length).toEqual(1);
+      expect(getData).toHaveBeenCalledWith({
+        endpoint: `${solutionsApiUrl}/api/v1/suppliers?name=some-supp`,
+        accessToken: 'access_token',
+        logger,
+      });
+    });
+  });
+});

--- a/app/pages/sections/supplier/select/controller.test.js
+++ b/app/pages/sections/supplier/select/controller.test.js
@@ -20,7 +20,7 @@ describe('supplier select controller', () => {
       getData
         .mockResolvedValueOnce({ data: [] });
 
-      await findSuppliers({ supplierNameToFind: 'some-supp', accessToken: 'access_token' });
+      await findSuppliers({ name: 'some-supp', accessToken: 'access_token' });
       expect(getData.mock.calls.length).toEqual(1);
       expect(getData).toHaveBeenCalledWith({
         endpoint: `${solutionsApiUrl}/api/v1/suppliers?name=some-supp`,

--- a/app/pages/sections/supplier/select/manifest.json
+++ b/app/pages/sections/supplier/select/manifest.json
@@ -1,0 +1,12 @@
+{
+  "backLinkText": "Go back",
+  "title": "Suppliers found",
+  "description": "These are the suppliers that match the search terms you provided. Select the one you're looking for.",
+  "questions": [
+    {
+      "id": "selectSupplier",
+      "mainAdvice": "Select Supplier"
+    }
+  ],
+  "continueButtonText": "Continue"
+}

--- a/app/pages/sections/supplier/select/template.njk
+++ b/app/pages/sections/supplier/select/template.njk
@@ -1,7 +1,7 @@
 {% extends 'includes/layout.njk' %}
 {% from 'components/back-link/macro.njk' import backLink %}
 {% from 'components/bc-button/macro.njk' import bcButton %}
-{% from 'components/text-field/macro.njk' import textField %}
+{% from 'components/radiobutton-options/macro.njk' import radiobuttonOptions %}
 {% from 'components/bc-error-summary/macro.njk' import bcErrorSummary %}
 
 {% block body %}
@@ -20,6 +20,12 @@
 
         <form method="post">
           <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
+
+          {{
+            radiobuttonOptions({
+              question: questions[0]
+            })
+          }}
 
           {{ bcButton({
               dataTestId: "continue-button",

--- a/app/pages/sections/supplier/select/template.njk
+++ b/app/pages/sections/supplier/select/template.njk
@@ -1,0 +1,32 @@
+{% extends 'includes/layout.njk' %}
+{% from 'components/back-link/macro.njk' import backLink %}
+{% from 'components/bc-button/macro.njk' import bcButton %}
+{% from 'components/text-field/macro.njk' import textField %}
+{% from 'components/bc-error-summary/macro.njk' import bcErrorSummary %}
+
+{% block body %}
+  <div class="nhsuk-width-container" data-test-id="supplier-select-page">
+    <div data-test-id="go-back-link">
+      {{ backLink({
+        href: backLinkHref,
+        text: backLinkText
+      }) }}
+    </div>
+
+    <div class="nhsuk-grid-row">
+      <div class="nhsuk-grid-column-two-thirds">
+        <h1 data-test-id="supplier-select-page-title" class="nhsuk-u-margin-top-7 nhsuk-u-margin-bottom-3">{{ title }}</h1>
+        <h2 data-test-id="supplier-select-page-description" class="nhsuk-u-font-size-24 nhsuk-u-margin-bottom-6">{{ description }}</h2>
+
+        <form method="post">
+          <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
+
+          {{ bcButton({
+              dataTestId: "continue-button",
+              text: continueButtonText,
+              classes: "nhsuk-u-margin-top-9"
+          })}}
+        </form>
+    </div>
+  </div>
+{% endblock %}

--- a/app/pages/sections/supplier/select/template.test.js
+++ b/app/pages/sections/supplier/select/template.test.js
@@ -1,0 +1,74 @@
+import { componentTester } from '../../../../test-utils/componentTester';
+import manifest from './manifest.json';
+
+const setup = {
+  template: {
+    path: 'pages/sections/supplier/select/template.njk',
+  },
+};
+
+describe('supplier select page', () => {
+  it('should render a backLink', componentTester(setup, (harness) => {
+    const context = {
+      orderId: 'order-1',
+      backLinkText: 'Go back',
+      backLinkHref: '/organisation/order-1/supplier/search',
+    };
+
+    harness.request(context, ($) => {
+      const backLink = $('[data-test-id="go-back-link"]');
+      expect(backLink.length).toEqual(1);
+      expect(backLink.text().trim()).toEqual('Go back');
+      expect($(backLink).find('a').attr('href')).toEqual('/organisation/order-1/supplier/search');
+    });
+  }));
+
+  it('should render the supplier-select page title', componentTester(setup, (harness) => {
+    const context = {
+      title: 'Suppliers found',
+    };
+
+    harness.request(context, ($) => {
+      const title = $('h1[data-test-id="supplier-select-page-title"]');
+      expect(title.length).toEqual(1);
+      expect(title.text().trim()).toEqual(context.title);
+    });
+  }));
+
+  it('should render the supplier-select page description', componentTester(setup, (harness) => {
+    const context = {
+      description: manifest.description,
+    };
+
+    harness.request(context, ($) => {
+      const description = $('h2[data-test-id="supplier-select-page-description"]');
+      expect(description.length).toEqual(1);
+      expect(description.text().trim()).toEqual(context.description);
+    });
+  }));
+
+  it('should render hidden input with csrf token', componentTester(setup, (harness) => {
+    const context = {
+      csrfToken: 'mockCsrfToken',
+    };
+
+    harness.request(context, ($) => {
+      const formElement = $('input[name=_csrf]');
+      expect(formElement.length).toEqual(1);
+      expect(formElement.attr('type')).toEqual('hidden');
+      expect(formElement.attr('value')).toEqual(context.csrfToken);
+    });
+  }));
+
+  it('should render the "Continue" button', componentTester(setup, (harness) => {
+    const context = {
+      continueButtonText: 'Continue',
+    };
+
+    harness.request(context, ($) => {
+      const button = $('[data-test-id="continue-button"] button');
+      expect(button.length).toEqual(1);
+      expect(button.text().trim()).toEqual(context.continueButtonText);
+    });
+  }));
+});

--- a/app/pages/sections/supplier/select/template.test.js
+++ b/app/pages/sections/supplier/select/template.test.js
@@ -60,6 +60,34 @@ describe('supplier select page', () => {
     });
   }));
 
+  it('should render the "Select Supplier" radio button options component', componentTester(setup, (harness) => {
+    const context = {
+      questions: [
+        {
+          id: 'selectSupplier',
+          mainAdvice: 'Select Supplier',
+          options: [
+            {
+              value: 'supplier-1',
+              text: 'Supplier 1',
+            },
+            {
+              value: 'supplier-2',
+              text: 'Supplier 2',
+            },
+          ],
+        },
+      ],
+    };
+
+    harness.request(context, ($) => {
+      const selectSupplierRadioOptions = $('[data-test-id="question-selectSupplier"]');
+      expect(selectSupplierRadioOptions.length).toEqual(1);
+      expect(selectSupplierRadioOptions.find('legend').text().trim()).toEqual(context.questions[0].mainAdvice);
+      expect(selectSupplierRadioOptions.find('input').length).toEqual(2);
+    });
+  }));
+
   it('should render the "Continue" button', componentTester(setup, (harness) => {
     const context = {
       continueButtonText: 'Continue',

--- a/app/pages/sections/supplier/select/ui.test.js
+++ b/app/pages/sections/supplier/select/ui.test.js
@@ -4,7 +4,8 @@ import { extractInnerText } from 'buying-catalogue-library';
 import { solutionsApiUrl } from '../../../../config';
 import content from './manifest.json';
 
-const pageUrl = 'http://localhost:1234/organisation/order-1/supplier/search/select';
+const pageUrl = 'http://localhost:1234/organisation/order-1/supplier/search/select?name=some-supp';
+const pageUrlWithoutQueryString = 'http://localhost:1234/organisation/order-1/supplier/search/select';
 
 const setCookies = ClientFunction(() => {
   const cookieValue = JSON.stringify({
@@ -52,7 +53,7 @@ test('should render Supplier select page', async (t) => {
     .reply(200, [{}]);
 
   await pageSetup(t, true);
-  await t.navigateTo(`${pageUrl}?name=some-supp`);
+  await t.navigateTo(pageUrl);
   const page = Selector('[data-test-id="supplier-select-page"]');
 
   await t
@@ -65,7 +66,7 @@ test('should navigate to /organisation/order-1/supplier/search when click on bac
     .reply(200, [{}]);
 
   await pageSetup(t, true);
-  await t.navigateTo(`${pageUrl}?name=some-supp`);
+  await t.navigateTo(pageUrl);
 
   const goBackLink = Selector('[data-test-id="go-back-link"] a');
 
@@ -81,7 +82,7 @@ test('should render the title', async (t) => {
     .reply(200, [{}]);
 
   await pageSetup(t, true);
-  await t.navigateTo(`${pageUrl}?name=some-supp`);
+  await t.navigateTo(pageUrl);
 
   const title = Selector('h1[data-test-id="supplier-select-page-title"]');
 
@@ -96,7 +97,7 @@ test('should render the description', async (t) => {
     .reply(200, [{}]);
 
   await pageSetup(t, true);
-  await t.navigateTo(`${pageUrl}?name=some-supp`);
+  await t.navigateTo(pageUrl);
 
   const description = Selector('h2[data-test-id="supplier-select-page-description"]');
 
@@ -114,7 +115,7 @@ test('should render a selectSupplier question as radio button options', async (t
     ]);
 
   await pageSetup(t, true);
-  await t.navigateTo(`${pageUrl}?name=some-supp`);
+  await t.navigateTo(pageUrl);
 
   const selectSupplierRadioOptions = Selector('[data-test-id="question-selectSupplier"]');
 
@@ -136,7 +137,7 @@ test('should render the Continue button', async (t) => {
     .reply(200, [{}]);
 
   await pageSetup(t, true);
-  await t.navigateTo(`${pageUrl}?name=some-supp`);
+  await t.navigateTo(pageUrl);
 
   const button = Selector('[data-test-id="continue-button"] button');
 
@@ -147,7 +148,7 @@ test('should render the Continue button', async (t) => {
 
 test('should redirect to the search page if a supplier to find is not pass in the url', async (t) => {
   await pageSetup(t, true);
-  await t.navigateTo(`${pageUrl}`);
+  await t.navigateTo(pageUrlWithoutQueryString);
 
   await t
     .expect(getLocation()).eql('http://localhost:1234/order/organisation/order-1/supplier/search');
@@ -160,7 +161,7 @@ test('should show the error page if no suppliers are returned', async (t) => {
     .reply(200, []);
 
   await pageSetup(t, true);
-  await t.navigateTo(`${pageUrl}?name=some-supp`);
+  await t.navigateTo(pageUrl);
 
   const backLink = Selector('[data-test-id="error-back-link"]');
   const errorTitle = Selector('[data-test-id="error-title"]');

--- a/app/pages/sections/supplier/select/ui.test.js
+++ b/app/pages/sections/supplier/select/ui.test.js
@@ -105,6 +105,31 @@ test('should render the description', async (t) => {
     .expect(await extractInnerText(description)).eql(content.description);
 });
 
+test('should render a selectSupplier question as radio button options', async (t) => {
+  nock(solutionsApiUrl)
+    .get('/api/v1/suppliers?name=some-supp')
+    .reply(200, [
+      { supplierId: 'supplier-1', name: 'Supplier 1' },
+      { supplierId: 'supplier-2', name: 'Supplier 2' },
+    ]);
+
+  await pageSetup(t, true);
+  await t.navigateTo(`${pageUrl}?supplierNameToFind=some-supp`);
+
+  const selectSupplierRadioOptions = Selector('[data-test-id="question-selectSupplier"]');
+
+  await t
+    .expect(selectSupplierRadioOptions.exists).ok()
+    .expect(await extractInnerText(selectSupplierRadioOptions.find('legend'))).eql(content.questions[0].mainAdvice)
+    .expect(selectSupplierRadioOptions.find('input').count).eql(2)
+
+    .expect(selectSupplierRadioOptions.find('input').nth(0).getAttribute('value')).eql('supplier-1')
+    .expect(await extractInnerText(selectSupplierRadioOptions.find('label').nth(0))).eql('Supplier 1')
+
+    .expect(selectSupplierRadioOptions.find('input').nth(1).getAttribute('value')).eql('supplier-2')
+    .expect(await extractInnerText(selectSupplierRadioOptions.find('label').nth(1))).eql('Supplier 2');
+});
+
 test('should render the Continue button', async (t) => {
   nock(solutionsApiUrl)
     .get('/api/v1/suppliers?name=some-supp')

--- a/app/pages/sections/supplier/select/ui.test.js
+++ b/app/pages/sections/supplier/select/ui.test.js
@@ -52,7 +52,7 @@ test('should render Supplier select page', async (t) => {
     .reply(200, [{}]);
 
   await pageSetup(t, true);
-  await t.navigateTo(`${pageUrl}?supplierNameToFind=some-supp`);
+  await t.navigateTo(`${pageUrl}?name=some-supp`);
   const page = Selector('[data-test-id="supplier-select-page"]');
 
   await t
@@ -65,7 +65,7 @@ test('should navigate to /organisation/order-1/supplier/search when click on bac
     .reply(200, [{}]);
 
   await pageSetup(t, true);
-  await t.navigateTo(`${pageUrl}?supplierNameToFind=some-supp`);
+  await t.navigateTo(`${pageUrl}?name=some-supp`);
 
   const goBackLink = Selector('[data-test-id="go-back-link"] a');
 
@@ -81,7 +81,7 @@ test('should render the title', async (t) => {
     .reply(200, [{}]);
 
   await pageSetup(t, true);
-  await t.navigateTo(`${pageUrl}?supplierNameToFind=some-supp`);
+  await t.navigateTo(`${pageUrl}?name=some-supp`);
 
   const title = Selector('h1[data-test-id="supplier-select-page-title"]');
 
@@ -96,7 +96,7 @@ test('should render the description', async (t) => {
     .reply(200, [{}]);
 
   await pageSetup(t, true);
-  await t.navigateTo(`${pageUrl}?supplierNameToFind=some-supp`);
+  await t.navigateTo(`${pageUrl}?name=some-supp`);
 
   const description = Selector('h2[data-test-id="supplier-select-page-description"]');
 
@@ -114,7 +114,7 @@ test('should render a selectSupplier question as radio button options', async (t
     ]);
 
   await pageSetup(t, true);
-  await t.navigateTo(`${pageUrl}?supplierNameToFind=some-supp`);
+  await t.navigateTo(`${pageUrl}?name=some-supp`);
 
   const selectSupplierRadioOptions = Selector('[data-test-id="question-selectSupplier"]');
 
@@ -136,7 +136,7 @@ test('should render the Continue button', async (t) => {
     .reply(200, [{}]);
 
   await pageSetup(t, true);
-  await t.navigateTo(`${pageUrl}?supplierNameToFind=some-supp`);
+  await t.navigateTo(`${pageUrl}?name=some-supp`);
 
   const button = Selector('[data-test-id="continue-button"] button');
 
@@ -160,7 +160,7 @@ test('should show the error page if no suppliers are returned', async (t) => {
     .reply(200, []);
 
   await pageSetup(t, true);
-  await t.navigateTo(`${pageUrl}?supplierNameToFind=some-supp`);
+  await t.navigateTo(`${pageUrl}?name=some-supp`);
 
   const backLink = Selector('[data-test-id="error-back-link"]');
   const errorTitle = Selector('[data-test-id="error-title"]');

--- a/app/pages/sections/supplier/select/ui.test.js
+++ b/app/pages/sections/supplier/select/ui.test.js
@@ -1,0 +1,68 @@
+import nock from 'nock';
+import { ClientFunction, Selector } from 'testcafe';
+import { extractInnerText } from 'buying-catalogue-library';
+import { solutionsApiUrl } from '../../../../config';
+
+const pageUrl = 'http://localhost:1234/organisation/order-1/supplier/search/select';
+
+const setCookies = ClientFunction(() => {
+  const cookieValue = JSON.stringify({
+    id: '88421113', name: 'Cool Dude', ordering: 'manage', primaryOrganisationId: 'org-id',
+  });
+
+  document.cookie = `fakeToken=${cookieValue}`;
+});
+
+const pageSetup = async (t, withAuth = false) => {
+  if (withAuth) {
+    await setCookies();
+  }
+};
+
+
+const getLocation = ClientFunction(() => document.location.href);
+
+fixture('Supplier select page')
+  .page('http://localhost:1234/some-fake-page')
+  .afterEach(async (t) => {
+    const isDone = nock.isDone();
+    if (!isDone) {
+      nock.cleanAll();
+    }
+
+    await t.expect(isDone).ok('Not all nock interceptors were used!');
+  });
+
+test('when user is not authenticated - should navigate to the identity server login page', async (t) => {
+  await pageSetup(t);
+  nock('http://identity-server')
+    .get('/login')
+    .reply(200);
+
+  await t.navigateTo(pageUrl);
+
+  await t
+    .expect(getLocation()).eql('http://identity-server/login');
+});
+
+test('should show the error page if no suppliers are returned', async (t) => {
+  nock(solutionsApiUrl)
+    .get('/api/v1/suppliers?name=some-supp')
+    .reply(200, []);
+
+  await pageSetup(t, true);
+  await t.navigateTo(`${pageUrl}?supplierNameToFind=some-supp`);
+
+  const backLink = Selector('[data-test-id="error-back-link"]');
+  const errorTitle = Selector('[data-test-id="error-title"]');
+  const errorDescription = Selector('[data-test-id="error-description"]');
+
+  await t
+    .expect(backLink.exists).ok()
+    .expect(await extractInnerText(backLink)).eql('Go back to search')
+    .expect(backLink.find('a').getAttribute('href')).ok('/order/organisations/order-1/supplier/search')
+    .expect(errorTitle.exists).ok()
+    .expect(await extractInnerText(errorTitle)).eql('No Supplier found')
+    .expect(errorDescription.exists).ok()
+    .expect(await extractInnerText(errorDescription)).eql("There are no suppliers that match the search terms you've provided. Try searching again.");
+});

--- a/app/pages/sections/supplier/select/ui.test.js
+++ b/app/pages/sections/supplier/select/ui.test.js
@@ -45,6 +45,15 @@ test('when user is not authenticated - should navigate to the identity server lo
     .expect(getLocation()).eql('http://identity-server/login');
 });
 
+test('should redirect to the search page if a supplier to find is not pass in the url', async (t) => {
+  await pageSetup(t, true);
+  await t.navigateTo(`${pageUrl}`);
+
+  await t
+    .expect(getLocation()).eql('http://localhost:1234/order/organisation/order-1/supplier/search');
+});
+
+
 test('should show the error page if no suppliers are returned', async (t) => {
   nock(solutionsApiUrl)
     .get('/api/v1/suppliers?name=some-supp')
@@ -60,7 +69,7 @@ test('should show the error page if no suppliers are returned', async (t) => {
   await t
     .expect(backLink.exists).ok()
     .expect(await extractInnerText(backLink)).eql('Go back to search')
-    .expect(backLink.find('a').getAttribute('href')).ok('/order/organisations/order-1/supplier/search')
+    .expect(backLink.find('a').getAttribute('href')).ok('/order/organisation/order-1/supplier/search')
     .expect(errorTitle.exists).ok()
     .expect(await extractInnerText(errorTitle)).eql('No Supplier found')
     .expect(errorDescription.exists).ok()

--- a/app/pages/sections/supplier/select/ui.test.js
+++ b/app/pages/sections/supplier/select/ui.test.js
@@ -2,6 +2,7 @@ import nock from 'nock';
 import { ClientFunction, Selector } from 'testcafe';
 import { extractInnerText } from 'buying-catalogue-library';
 import { solutionsApiUrl } from '../../../../config';
+import content from './manifest.json';
 
 const pageUrl = 'http://localhost:1234/organisation/order-1/supplier/search/select';
 
@@ -43,6 +44,80 @@ test('when user is not authenticated - should navigate to the identity server lo
 
   await t
     .expect(getLocation()).eql('http://identity-server/login');
+});
+
+test('should render Supplier select page', async (t) => {
+  nock(solutionsApiUrl)
+    .get('/api/v1/suppliers?name=some-supp')
+    .reply(200, [{}]);
+
+  await pageSetup(t, true);
+  await t.navigateTo(`${pageUrl}?supplierNameToFind=some-supp`);
+  const page = Selector('[data-test-id="supplier-select-page"]');
+
+  await t
+    .expect(page.exists).ok();
+});
+
+test('should navigate to /organisation/order-1/supplier/search when click on backlink', async (t) => {
+  nock(solutionsApiUrl)
+    .get('/api/v1/suppliers?name=some-supp')
+    .reply(200, [{}]);
+
+  await pageSetup(t, true);
+  await t.navigateTo(`${pageUrl}?supplierNameToFind=some-supp`);
+
+  const goBackLink = Selector('[data-test-id="go-back-link"] a');
+
+  await t
+    .expect(goBackLink.exists).ok()
+    .click(goBackLink)
+    .expect(getLocation()).eql('http://localhost:1234/order/organisation/order-1/supplier/search');
+});
+
+test('should render the title', async (t) => {
+  nock(solutionsApiUrl)
+    .get('/api/v1/suppliers?name=some-supp')
+    .reply(200, [{}]);
+
+  await pageSetup(t, true);
+  await t.navigateTo(`${pageUrl}?supplierNameToFind=some-supp`);
+
+  const title = Selector('h1[data-test-id="supplier-select-page-title"]');
+
+  await t
+    .expect(title.exists).ok()
+    .expect(await extractInnerText(title)).eql(content.title);
+});
+
+test('should render the description', async (t) => {
+  nock(solutionsApiUrl)
+    .get('/api/v1/suppliers?name=some-supp')
+    .reply(200, [{}]);
+
+  await pageSetup(t, true);
+  await t.navigateTo(`${pageUrl}?supplierNameToFind=some-supp`);
+
+  const description = Selector('h2[data-test-id="supplier-select-page-description"]');
+
+  await t
+    .expect(description.exists).ok()
+    .expect(await extractInnerText(description)).eql(content.description);
+});
+
+test('should render the Continue button', async (t) => {
+  nock(solutionsApiUrl)
+    .get('/api/v1/suppliers?name=some-supp')
+    .reply(200, [{}]);
+
+  await pageSetup(t, true);
+  await t.navigateTo(`${pageUrl}?supplierNameToFind=some-supp`);
+
+  const button = Selector('[data-test-id="continue-button"] button');
+
+  await t
+    .expect(button.exists).ok()
+    .expect(await extractInnerText(button)).eql(content.continueButtonText);
 });
 
 test('should redirect to the search page if a supplier to find is not pass in the url', async (t) => {

--- a/app/routes.js
+++ b/app/routes.js
@@ -10,7 +10,7 @@ import { getDescriptionContext, getDescriptionErrorContext, postOrPutDescription
 import {
   getSupplierSearchPageContext, validateSupplierSearchForm, getSupplierSearchPageErrorContext,
 } from './pages/sections/supplier/search/controller';
-import { findSuppliers } from './pages/sections/supplier/select/controller';
+import { findSuppliers, getSupplierSelectPageContext } from './pages/sections/supplier/select/controller';
 import includesContext from './includes/manifest.json';
 import { getTaskListPageContext } from './pages/task-list/controller';
 import { getCallOffOrderingPartyContext } from './pages/sections/call-off-ordering-party/controller';
@@ -124,7 +124,9 @@ export const routes = (authProvider) => {
       });
 
       if (suppliersFound.length > 0) {
-        return res.status(200).send(`${suppliersFound.length} suppliers found`);
+        const context = await getSupplierSelectPageContext({ orderId });
+    
+        return res.render('pages/sections/supplier/select/template.njk', addContext({ context, user: req.user, csrfToken: req.csrfToken() }));
       }
 
       throw new ErrorContext({

--- a/app/routes.js
+++ b/app/routes.js
@@ -130,6 +130,10 @@ export const routes = (authProvider) => {
     return res.render('pages/sections/supplier/search/template.njk', addContext({ context, user: req.user, csrfToken: req.csrfToken() }));
   }));
 
+  router.get('/organisation/:orderId/supplier/search/select', authProvider.authorise({ claim: 'ordering' }), withCatch(authProvider, async (req, res) => {
+    res.status(200).send('supplier select page');
+  }));
+
   router.get('*', (req) => {
     throw new ErrorContext({
       status: 404,

--- a/app/routes.js
+++ b/app/routes.js
@@ -103,10 +103,26 @@ export const routes = (authProvider) => {
     const response = validateSupplierSearchForm({ data: req.body });
 
     if (response.success) {
+      return res.redirect(`${config.baseUrl}/organisation/${orderId}/supplier/search?supplierNameToFind=${req.body.supplierName}`);
+    }
+
+    const context = await getSupplierSearchPageErrorContext({
+      orderId,
+      validationErrors: response.errors,
+    });
+
+    return res.render('pages/sections/supplier/search/template.njk', addContext({ context, user: req.user, csrfToken: req.csrfToken() }));
+  }));
+
+  router.get('/organisation/:orderId/supplier/search/select', authProvider.authorise({ claim: 'ordering' }), withCatch(authProvider, async (req, res) => {
+    const { orderId } = req.params;
+    const { supplierNameToFind } = req.query;
+
+    if (supplierNameToFind) {
       const accessToken = extractAccessToken({ req, tokenType: 'access' });
 
       const suppliersFound = await findSuppliers({
-        supplierNameToFind: req.body.supplierName, accessToken,
+        supplierNameToFind, accessToken,
       });
 
       if (suppliersFound.length > 0) {
@@ -121,17 +137,7 @@ export const routes = (authProvider) => {
         backLinkHref: `${config.baseUrl}/organisation/${orderId}/supplier/search`,
       });
     }
-
-    const context = await getSupplierSearchPageErrorContext({
-      orderId,
-      validationErrors: response.errors,
-    });
-
-    return res.render('pages/sections/supplier/search/template.njk', addContext({ context, user: req.user, csrfToken: req.csrfToken() }));
-  }));
-
-  router.get('/organisation/:orderId/supplier/search/select', authProvider.authorise({ claim: 'ordering' }), withCatch(authProvider, async (req, res) => {
-    res.status(200).send('supplier select page');
+    res.redirect(`${config.baseUrl}/organisation/${orderId}/supplier/search`);
   }));
 
   router.get('*', (req) => {

--- a/app/routes.js
+++ b/app/routes.js
@@ -124,7 +124,7 @@ export const routes = (authProvider) => {
       });
 
       if (suppliersFound.length > 0) {
-        const context = getSupplierSelectPageContext({ orderId });
+        const context = getSupplierSelectPageContext({ orderId, suppliers: suppliersFound });
         return res.render('pages/sections/supplier/select/template.njk', addContext({ context, user: req.user, csrfToken: req.csrfToken() }));
       }
 

--- a/app/routes.js
+++ b/app/routes.js
@@ -116,7 +116,7 @@ export const routes = (authProvider) => {
     const response = validateSupplierSearchForm({ data: req.body });
 
     if (response.success) {
-      return res.redirect(`${config.baseUrl}/organisation/${orderId}/supplier/search?supplierNameToFind=${req.body.supplierName}`);
+      return res.redirect(`${config.baseUrl}/organisation/${orderId}/supplier/search?name=${req.body.supplierName}`);
     }
 
     const context = await getSupplierSearchPageErrorContext({
@@ -129,13 +129,13 @@ export const routes = (authProvider) => {
 
   router.get('/organisation/:orderId/supplier/search/select', authProvider.authorise({ claim: 'ordering' }), withCatch(authProvider, async (req, res) => {
     const { orderId } = req.params;
-    const { supplierNameToFind } = req.query;
+    const { name } = req.query;
 
-    if (supplierNameToFind) {
+    if (name) {
       const accessToken = extractAccessToken({ req, tokenType: 'access' });
 
       const suppliersFound = await findSuppliers({
-        supplierNameToFind, accessToken,
+        name, accessToken,
       });
 
       if (suppliersFound.length > 0) {

--- a/app/routes.js
+++ b/app/routes.js
@@ -124,8 +124,7 @@ export const routes = (authProvider) => {
       });
 
       if (suppliersFound.length > 0) {
-        const context = await getSupplierSelectPageContext({ orderId });
-    
+        const context = getSupplierSelectPageContext({ orderId });
         return res.render('pages/sections/supplier/select/template.njk', addContext({ context, user: req.user, csrfToken: req.csrfToken() }));
       }
 

--- a/app/routes.js
+++ b/app/routes.js
@@ -137,6 +137,7 @@ export const routes = (authProvider) => {
         backLinkHref: `${config.baseUrl}/organisation/${orderId}/supplier/search`,
       });
     }
+
     return res.redirect(`${config.baseUrl}/organisation/${orderId}/supplier/search`);
   }));
 

--- a/app/routes.js
+++ b/app/routes.js
@@ -8,11 +8,9 @@ import { withCatch, getHealthCheckDependencies, extractAccessToken } from './hel
 import { getDashboardContext } from './pages/dashboard/controller';
 import { getDescriptionContext, getDescriptionErrorContext, postOrPutDescription } from './pages/sections/description/controller';
 import {
-  getSupplierSearchPageContext,
-  validateSupplierSearchForm,
-  findSuppliers,
-  getSupplierSearchPageErrorContext,
+  getSupplierSearchPageContext, validateSupplierSearchForm, getSupplierSearchPageErrorContext,
 } from './pages/sections/supplier/search/controller';
+import { findSuppliers } from './pages/sections/supplier/select/controller';
 import includesContext from './includes/manifest.json';
 import { getTaskListPageContext } from './pages/task-list/controller';
 import { getCallOffOrderingPartyContext } from './pages/sections/call-off-ordering-party/controller';

--- a/app/routes.js
+++ b/app/routes.js
@@ -137,7 +137,7 @@ export const routes = (authProvider) => {
         backLinkHref: `${config.baseUrl}/organisation/${orderId}/supplier/search`,
       });
     }
-    res.redirect(`${config.baseUrl}/organisation/${orderId}/supplier/search`);
+    return res.redirect(`${config.baseUrl}/organisation/${orderId}/supplier/search`);
   }));
 
   router.get('*', (req) => {

--- a/app/routes.test.js
+++ b/app/routes.test.js
@@ -16,7 +16,7 @@ import * as taskListController from './pages/task-list/controller';
 import * as descriptionController from './pages/sections/description/controller';
 import * as orderingPartyController from './pages/sections/call-off-ordering-party/controller';
 import * as supplierSearchController from './pages/sections/supplier/search/controller';
-
+import * as supplierSelectController from './pages/sections/supplier/select/controller';
 
 jest.mock('./logger');
 
@@ -462,7 +462,7 @@ describe('routes', () => {
     ));
 
     it('should show the number of supplier found if there are no validation errors and suppliers were returned', async () => {
-      supplierSearchController.findSuppliers = jest.fn()
+      supplierSelectController.findSuppliers = jest.fn()
         .mockImplementation(() => Promise.resolve([
           { supplierId: 'some-supplier-id', name: 'some-supplier-name' }]));
 
@@ -478,7 +478,7 @@ describe('routes', () => {
     });
 
     it('should show the error page indicating no suppliers found', async () => {
-      supplierSearchController.findSuppliers = jest.fn()
+      supplierSelectController.findSuppliers = jest.fn()
         .mockImplementation(() => Promise.resolve([]));
 
       return request(setUpFakeApp())

--- a/app/routes.test.js
+++ b/app/routes.test.js
@@ -461,7 +461,7 @@ describe('routes', () => {
       })
     ));
 
-    it('should show the number of supplier found if there are no validation errors and suppliers were returned', async () => {
+    it('should show the supplier select if there are no validation errors and suppliers were returned', async () => {
       supplierSelectController.findSuppliers = jest.fn()
         .mockImplementation(() => Promise.resolve([
           { supplierId: 'some-supplier-id', name: 'some-supplier-name' }]));
@@ -473,7 +473,7 @@ describe('routes', () => {
         .then((res) => {
           expect(res.text.includes('data-test-id="error-summary"')).toEqual(false);
           expect(res.text.includes('data-test-id="error-title"')).toEqual(false);
-          expect(res.text.includes('1 suppliers found')).toEqual(true);
+          expect(res.text.includes('data-test-id="supplier-select-page"')).toBeTruthy();
         });
     });
 

--- a/app/routes.test.js
+++ b/app/routes.test.js
@@ -443,7 +443,7 @@ describe('routes', () => {
   });
 
   describe('GET /organisation/:orderId/supplier/search/select', () => {
-    const path = '/organisation/some-order-id/supplier/search/select';
+    const path = '/organisation/some-order-id/supplier/search/select?supplierNameToFind=some-supp';
 
     it('should redirect to the login page if the user is not logged in', () => (
       testAuthorisedGetPathForUnauthenticatedUser({
@@ -461,35 +461,14 @@ describe('routes', () => {
       })
     ));
 
-    it('should return the correct status and text when the user is authorised', () => request(setUpFakeApp())
-      .get(path)
-      .set('Cookie', [mockAuthorisedCookie])
-      .expect(200)
-      .then((res) => {
-        expect(res.text.includes('supplier select page')).toBeTruthy();
-        expect(res.text.includes('data-test-id="error-title"')).toBeFalsy();
-      }));
-
     it('should show the number of supplier found if there are no validation errors and suppliers were returned', async () => {
-      supplierSearchController.validateSupplierSearchForm = jest.fn()
-        .mockImplementation(() => ({ success: true }));
-
       supplierSearchController.findSuppliers = jest.fn()
         .mockImplementation(() => Promise.resolve([
           { supplierId: 'some-supplier-id', name: 'some-supplier-name' }]));
 
-      const { cookies, csrfToken } = await getCsrfTokenFromGet({
-        app: request(setUpFakeApp()), csrfPagePath: path, mockAuthorisedCookie,
-      });
-
       return request(setUpFakeApp())
-        .post(path)
-        .type('form')
-        .set('Cookie', [cookies, mockAuthorisedCookie])
-        .send({
-          supplierName: '',
-          _csrf: csrfToken,
-        })
+        .get(path)
+        .set('Cookie', [mockAuthorisedCookie])
         .expect(200)
         .then((res) => {
           expect(res.text.includes('data-test-id="error-summary"')).toEqual(false);
@@ -499,24 +478,12 @@ describe('routes', () => {
     });
 
     it('should show the error page indicating no suppliers found', async () => {
-      supplierSearchController.validateSupplierSearchForm = jest.fn()
-        .mockImplementation(() => ({ success: true }));
-
       supplierSearchController.findSuppliers = jest.fn()
         .mockImplementation(() => Promise.resolve([]));
 
-      const { cookies, csrfToken } = await getCsrfTokenFromGet({
-        app: request(setUpFakeApp()), csrfPagePath: path, mockAuthorisedCookie,
-      });
-
       return request(setUpFakeApp())
-        .post(path)
-        .type('form')
-        .set('Cookie', [cookies, mockAuthorisedCookie])
-        .send({
-          supplierName: '',
-          _csrf: csrfToken,
-        })
+        .get(path)
+        .set('Cookie', [mockAuthorisedCookie])
         .expect(200)
         .then((res) => {
           expect(res.text.includes('data-test-id="error-title"')).toEqual(true);

--- a/app/routes.test.js
+++ b/app/routes.test.js
@@ -492,7 +492,7 @@ describe('routes', () => {
         });
     });
 
-    it('should redirect to /organisation/some-order-id/supplier/search/select?supplierNameToFind=some-supp if no validation errors', async () => {
+    it('should redirect to /organisation/some-order-id/supplier/search/select?name=some-supp if no validation errors', async () => {
       supplierSearchController.validateSupplierSearchForm = jest.fn()
         .mockImplementation(() => ({ success: true }));
 
@@ -511,13 +511,13 @@ describe('routes', () => {
         .expect(302)
         .then((res) => {
           expect(res.redirect).toEqual(true);
-          expect(res.headers.location).toEqual(`${baseUrl}/organisation/order-1/supplier/search?supplierNameToFind=some-supp`);
+          expect(res.headers.location).toEqual(`${baseUrl}/organisation/order-1/supplier/search?name=some-supp`);
         });
     });
   });
 
   describe('GET /organisation/:orderId/supplier/search/select', () => {
-    const path = '/organisation/some-order-id/supplier/search/select?supplierNameToFind=some-supp';
+    const path = '/organisation/some-order-id/supplier/search/select?name=some-supp';
 
     it('should redirect to the login page if the user is not logged in', () => (
       testAuthorisedGetPathForUnauthenticatedUser({

--- a/app/routes.test.js
+++ b/app/routes.test.js
@@ -475,6 +475,35 @@ describe('routes', () => {
     });
   });
 
+  describe('GET /organisation/:orderId/supplier/search/select', () => {
+    const path = '/organisation/some-order-id/supplier/search/select';
+
+    it('should redirect to the login page if the user is not logged in', () => (
+      testAuthorisedGetPathForUnauthenticatedUser({
+        app: request(setUpFakeApp()), pathToTest: path, expectedRedirectPath: 'http://identity-server/login',
+      })
+    ));
+
+    it('should show the error page indicating the user is not authorised if the user is logged in but not authorised', () => (
+      testAuthorisedGetPathForUnauthorisedUser({
+        app: request(setUpFakeApp()),
+        pathToTest: path,
+        mockUnauthorisedCookie,
+        expectedPageId: 'data-test-id="error-title"',
+        expectedPageMessage: 'You are not authorised to view this page',
+      })
+    ));
+
+    it('should return the correct status and text when the user is authorised', () => request(setUpFakeApp())
+      .get(path)
+      .set('Cookie', [mockAuthorisedCookie])
+      .expect(200)
+      .then((res) => {
+        expect(res.text.includes('supplier select page')).toBeTruthy();
+        expect(res.text.includes('data-test-id="error-title"')).toBeFalsy();
+      }));
+  });
+
   describe('GET *', () => {
     it('should return error page if url cannot be matched', done => request(setUpFakeApp())
       .get('/aaaa')

--- a/app/routes.test.js
+++ b/app/routes.test.js
@@ -418,6 +418,58 @@ describe('routes', () => {
         });
     });
 
+    it('should redirect to /organisation/some-order-id/supplier/search/select?supplierNameToFind=some-supp if no validation errors', async () => {
+      supplierSearchController.validateSupplierSearchForm = jest.fn()
+        .mockImplementation(() => ({ success: true }));
+
+      const { cookies, csrfToken } = await getCsrfTokenFromGet({
+        app: request(setUpFakeApp()), csrfPagePath: path, mockAuthorisedCookie,
+      });
+
+      return request(setUpFakeApp())
+        .post(path)
+        .type('form')
+        .set('Cookie', [cookies, mockAuthorisedCookie])
+        .send({
+          supplierName: 'some-supp',
+          _csrf: csrfToken,
+        })
+        .expect(302)
+        .then((res) => {
+          expect(res.redirect).toEqual(true);
+          expect(res.headers.location).toEqual(`${baseUrl}/organisation/order-1/supplier/search?supplierNameToFind=some-supp`);
+        });
+    });
+  });
+
+  describe('GET /organisation/:orderId/supplier/search/select', () => {
+    const path = '/organisation/some-order-id/supplier/search/select';
+
+    it('should redirect to the login page if the user is not logged in', () => (
+      testAuthorisedGetPathForUnauthenticatedUser({
+        app: request(setUpFakeApp()), pathToTest: path, expectedRedirectPath: 'http://identity-server/login',
+      })
+    ));
+
+    it('should show the error page indicating the user is not authorised if the user is logged in but not authorised', () => (
+      testAuthorisedGetPathForUnauthorisedUser({
+        app: request(setUpFakeApp()),
+        pathToTest: path,
+        mockUnauthorisedCookie,
+        expectedPageId: 'data-test-id="error-title"',
+        expectedPageMessage: 'You are not authorised to view this page',
+      })
+    ));
+
+    it('should return the correct status and text when the user is authorised', () => request(setUpFakeApp())
+      .get(path)
+      .set('Cookie', [mockAuthorisedCookie])
+      .expect(200)
+      .then((res) => {
+        expect(res.text.includes('supplier select page')).toBeTruthy();
+        expect(res.text.includes('data-test-id="error-title"')).toBeFalsy();
+      }));
+
     it('should show the number of supplier found if there are no validation errors and suppliers were returned', async () => {
       supplierSearchController.validateSupplierSearchForm = jest.fn()
         .mockImplementation(() => ({ success: true }));
@@ -473,35 +525,6 @@ describe('routes', () => {
           )).toEqual(true);
         });
     });
-  });
-
-  describe('GET /organisation/:orderId/supplier/search/select', () => {
-    const path = '/organisation/some-order-id/supplier/search/select';
-
-    it('should redirect to the login page if the user is not logged in', () => (
-      testAuthorisedGetPathForUnauthenticatedUser({
-        app: request(setUpFakeApp()), pathToTest: path, expectedRedirectPath: 'http://identity-server/login',
-      })
-    ));
-
-    it('should show the error page indicating the user is not authorised if the user is logged in but not authorised', () => (
-      testAuthorisedGetPathForUnauthorisedUser({
-        app: request(setUpFakeApp()),
-        pathToTest: path,
-        mockUnauthorisedCookie,
-        expectedPageId: 'data-test-id="error-title"',
-        expectedPageMessage: 'You are not authorised to view this page',
-      })
-    ));
-
-    it('should return the correct status and text when the user is authorised', () => request(setUpFakeApp())
-      .get(path)
-      .set('Cookie', [mockAuthorisedCookie])
-      .expect(200)
-      .then((res) => {
-        expect(res.text.includes('supplier select page')).toBeTruthy();
-        expect(res.text.includes('data-test-id="error-title"')).toBeFalsy();
-      }));
   });
 
   describe('GET *', () => {

--- a/app/routes.test.js
+++ b/app/routes.test.js
@@ -466,6 +466,9 @@ describe('routes', () => {
         .mockImplementation(() => Promise.resolve([
           { supplierId: 'some-supplier-id', name: 'some-supplier-name' }]));
 
+      supplierSelectController.getSupplierSelectPageContext = jest.fn()
+        .mockImplementation(() => {});
+
       return request(setUpFakeApp())
         .get(path)
         .set('Cookie', [mockAuthorisedCookie])

--- a/package-lock.json
+++ b/package-lock.json
@@ -3990,9 +3990,9 @@
       "dev": true
     },
     "buying-catalogue-components": {
-      "version": "1.1.71",
-      "resolved": "https://registry.npmjs.org/buying-catalogue-components/-/buying-catalogue-components-1.1.71.tgz",
-      "integrity": "sha512-2j+X5unMv0XUooSL6rMiDV/aJAAWekj9Xr0fbVWTYFx5tMk+aOIDHZ0q6VBLS/CSjxkZifP+9SjvxAXzxa00aQ==",
+      "version": "1.1.72",
+      "resolved": "https://registry.npmjs.org/buying-catalogue-components/-/buying-catalogue-components-1.1.72.tgz",
+      "integrity": "sha512-gOaunbFmZ6HqZIlCwCbMaMVv558NYLVxxEc0vwphvsUHFVdZs76HYWaHB5mhuq0iQhIwKVxOrEffvQA+9vb3cA==",
       "requires": {
         "buying-catalogue-library": "^1.0.5",
         "govuk-frontend": "^3.6.0",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "axios": "^0.19.0",
     "body-parser": "^1.19.0",
     "buying-catalogue-components": "^1.1.72",
-    "buying-catalogue-library": "^1.0.24",
     "compression": "^1.7.4",
     "cookie-parser": "^1.4.5",
     "csurf": "^1.11.0",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "axios": "^0.19.0",
     "body-parser": "^1.19.0",
     "buying-catalogue-components": "^1.1.72",
+    "buying-catalogue-library": "^1.0.24",
     "compression": "^1.7.4",
     "cookie-parser": "^1.4.5",
     "csurf": "^1.11.0",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "dependencies": {
     "axios": "^0.19.0",
     "body-parser": "^1.19.0",
-    "buying-catalogue-components": "^1.1.71",
+    "buying-catalogue-components": "^1.1.72",
     "buying-catalogue-library": "^1.0.24",
     "compression": "^1.7.4",
     "cookie-parser": "^1.4.5",


### PR DESCRIPTION
Story [AB#4840](https://buyingcatalog.visualstudio.com/c5f97979-5b03-4d10-ba8d-871d0526b408/_workitems/edit/4840)
Task [AB#7102](https://buyingcatalog.visualstudio.com/c5f97979-5b03-4d10-ba8d-871d0526b408/_workitems/edit/7102)

Just a note I had to move the actual finding of suppliers to the /select route. Since we won't be able to share the suppliers found from /search to /select without doing a search again in /select.

Now the /search just validates that something is entered and if so redirects to /select with the query string appended of what was entered.

<img width="1060" alt="Screenshot 2020-05-22 at 10 24 20" src="https://user-images.githubusercontent.com/9801518/82656661-0aa7ae00-9c1c-11ea-9099-b3077204297d.png">
