### PR TITLE
format date from commencement date

### DIFF
--- a/app/helpers/dateFormatter.js
+++ b/app/helpers/dateFormatter.js
@@ -6,3 +6,12 @@ export const formatDate = (date) => {
   const da = new Intl.DateTimeFormat('en', { day: 'numeric' }).format(d);
   return `${da} ${mo} ${ye}`;
 };
+
+export const formatCommencementDate = (date) => {
+  const d = new Date(date);
+  if (Number.isNaN(d.getTime())) return '';
+  const ye = new Intl.DateTimeFormat('en', { year: 'numeric' }).format(d);
+  const mo = new Intl.DateTimeFormat('en', { month: '2-digit' }).format(d);
+  const da = new Intl.DateTimeFormat('en', { day: '2-digit' }).format(d);
+  return `${da} ${mo} ${ye}`;
+};

--- a/app/helpers/dateFormatter.js
+++ b/app/helpers/dateFormatter.js
@@ -13,5 +13,5 @@ export const formatCommencementDate = (date) => {
   const ye = new Intl.DateTimeFormat('en', { year: 'numeric' }).format(d);
   const mo = new Intl.DateTimeFormat('en', { month: '2-digit' }).format(d);
   const da = new Intl.DateTimeFormat('en', { day: '2-digit' }).format(d);
-  return `${da} ${mo} ${ye}`;
+  return [da, mo, ye];
 };

--- a/app/helpers/dateFormatter.test.js
+++ b/app/helpers/dateFormatter.test.js
@@ -20,8 +20,8 @@ describe('formatDate', () => {
 
   describe('formatCommencementDate', () => {
     it('returns correctly formatted date when valid string is passed in', () => {
-      expect(formatCommencementDate('2020-05-06T11:29:52.4965647Z')).toEqual('06 05 2020');
-      expect(formatCommencementDate('2025-12-31T11:29:52.4965647Z')).toEqual('31 12 2025');
+      expect(formatCommencementDate('2020-05-06T11:29:52.4965647Z')).toEqual(['06', '05', '2020']);
+      expect(formatCommencementDate('2025-12-31T11:29:52.4965647Z')).toEqual(['31', '12', '2025']);
     });
 
     it('returns empty string when invalid string is passed in', () => {

--- a/app/helpers/dateFormatter.test.js
+++ b/app/helpers/dateFormatter.test.js
@@ -1,18 +1,37 @@
-import { formatDate } from './dateFormatter';
+import { formatDate, formatCommencementDate } from './dateFormatter';
 
 describe('formatDate', () => {
-  it('returns correctly formatted date when valid string is passed in', () => {
-    expect(formatDate('2020-05-06T11:29:52.4965647Z')).toEqual('6 May 2020');
-    expect(formatDate('2025-12-31T11:29:52.4965647Z')).toEqual('31 December 2025');
+  describe('formatDate', () => {
+    it('returns correctly formatted date when valid string is passed in', () => {
+      expect(formatDate('2020-05-06T11:29:52.4965647Z')).toEqual('6 May 2020');
+      expect(formatDate('2025-12-31T11:29:52.4965647Z')).toEqual('31 December 2025');
+    });
+
+    it('returns empty string when invalid string is passed in', () => {
+      expect(formatDate('2020-05-06T11:29:52.4965647Znnnn')).toEqual('');
+      expect(formatDate('2020-05-32T11:29:52.4965647Z')).toEqual('');
+      expect(formatDate('abc')).toEqual('');
+    });
+
+    it('returns empty string when nothing is passed in', () => {
+      expect(formatDate()).toEqual('');
+    });
   });
 
-  it('returns empty string when invalid string is passed in', () => {
-    expect(formatDate('2020-05-06T11:29:52.4965647Znnnn')).toEqual('');
-    expect(formatDate('2020-05-32T11:29:52.4965647Z')).toEqual('');
-    expect(formatDate('abc')).toEqual('');
-  });
+  describe('formatCommencementDate', () => {
+    it('returns correctly formatted date when valid string is passed in', () => {
+      expect(formatCommencementDate('2020-05-06T11:29:52.4965647Z')).toEqual('06 05 2020');
+      expect(formatCommencementDate('2025-12-31T11:29:52.4965647Z')).toEqual('31 12 2025');
+    });
 
-  it('returns empty string when nothing is passed in', () => {
-    expect(formatDate()).toEqual('');
+    it('returns empty string when invalid string is passed in', () => {
+      expect(formatCommencementDate('2020-05-06T11:29:52.4965647Znnnn')).toEqual('');
+      expect(formatCommencementDate('2020-05-32T11:29:52.4965647Z')).toEqual('');
+      expect(formatCommencementDate('abc')).toEqual('');
+    });
+
+    it('returns empty string when nothing is passed in', () => {
+      expect(formatCommencementDate()).toEqual('');
+    });
   });
 });

--- a/app/pages/sections/commencement-date/contextCreator.js
+++ b/app/pages/sections/commencement-date/contextCreator.js
@@ -1,9 +1,10 @@
 import manifest from './manifest.json';
 import { baseUrl } from '../../../config';
+import { formatCommencementDate } from '../../../helpers/dateFormatter';
 
 const addDataToManifest = (commencementDate) => {
   if (commencementDate) {
-    const [year, month, day] = commencementDate.split('-');
+    const [day, month, year] = formatCommencementDate(commencementDate).split(' ');
     return {
       ...manifest,
       questions: [{

--- a/app/pages/sections/commencement-date/contextCreator.js
+++ b/app/pages/sections/commencement-date/contextCreator.js
@@ -4,7 +4,7 @@ import { formatCommencementDate } from '../../../helpers/dateFormatter';
 
 const addDataToManifest = (commencementDate) => {
   if (commencementDate) {
-    const [day, month, year] = formatCommencementDate(commencementDate).split(' ');
+    const [day, month, year] = formatCommencementDate(commencementDate);
     return {
       ...manifest,
       questions: [{


### PR DESCRIPTION
Story [AB#4619](https://buyingcatalog.visualstudio.com/c5f97979-5b03-4d10-ba8d-871d0526b408/_workitems/edit/4619)
Task [AB#7130](https://buyingcatalog.visualstudio.com/c5f97979-5b03-4d10-ba8d-871d0526b408/_workitems/edit/7130)

The commencementDate from the API returns it like this "commencementDate": "2020-06-18T00:00:00"

We are not expecting the Timestamp bit which is why the Day was not showing. This fix will format the date returned from the API to one we can work with