### PR TITLE
Feature/5350 select solution route

### DIFF
--- a/app/pages/sections/catalogue-solutions/catalogue-solutions/contextCreator.js
+++ b/app/pages/sections/catalogue-solutions/catalogue-solutions/contextCreator.js
@@ -6,5 +6,6 @@ export const getContext = ({ orderId, orderDescription, catalogueSolutions }) =>
   title: `${manifest.title} ${orderId}`,
   orderDescription,
   catalogueSolutions,
+  addSolutionButtonHref: `${baseUrl}/organisation/${orderId}/catalogue-solutions/select`,
   backLinkHref: `${baseUrl}/organisation/${orderId}`,
 });

--- a/app/pages/sections/catalogue-solutions/catalogue-solutions/contextCreator.test.js
+++ b/app/pages/sections/catalogue-solutions/catalogue-solutions/contextCreator.test.js
@@ -55,6 +55,11 @@ describe('catalogue-solutions contextCreator', () => {
       expect(context.addSolutionButtonText).toEqual(manifest.addSolutionButtonText);
     });
 
+    it('should return the addSolutionButtonHref', () => {
+      const context = getContext({ orderId: 'order-1' });
+      expect(context.addSolutionButtonHref).toEqual(`${baseUrl}/organisation/order-1/catalogue-solutions/select`);
+    });
+
     it('should return the continueButtonText', () => {
       const context = getContext({ orderId: 'order-1' });
       expect(context.continueButtonText).toEqual(manifest.continueButtonText);

--- a/app/pages/sections/catalogue-solutions/catalogue-solutions/template.njk
+++ b/app/pages/sections/catalogue-solutions/catalogue-solutions/template.njk
@@ -29,7 +29,7 @@
         {{ bcButton({
             dataTestId: "add-solution-button",
             text: addSolutionButtonText,
-            href: '#',
+            href: addSolutionButtonHref,
             classes: "nhsuk-button--secondary nhsuk-u-margin-top-9"
         }) }}
       

--- a/app/pages/sections/catalogue-solutions/catalogue-solutions/template.test.js
+++ b/app/pages/sections/catalogue-solutions/catalogue-solutions/template.test.js
@@ -79,6 +79,7 @@ describe('catalogue-solutions page', () => {
   it('should render the "Add Catalogue Solution" button', componentTester(setup, (harness) => {
     const context = {
       addSolutionButtonText: 'Add Catalogue Solution',
+      addSolutionButtonHref: '#',
     };
 
     harness.request(context, ($) => {
@@ -87,6 +88,7 @@ describe('catalogue-solutions page', () => {
       expect(addSolutionButton.length).toEqual(1);
       expect(addSolutionButton.find('a').hasClass('nhsuk-button--secondary')).toEqual(true);
       expect(addSolutionButton.text().trim()).toEqual(context.addSolutionButtonText);
+      expect(addSolutionButton.find('a').attr('href')).toEqual('#');
     });
   }));
 

--- a/app/pages/sections/catalogue-solutions/catalogue-solutions/template.test.js
+++ b/app/pages/sections/catalogue-solutions/catalogue-solutions/template.test.js
@@ -79,7 +79,7 @@ describe('catalogue-solutions page', () => {
   it('should render the "Add Catalogue Solution" button', componentTester(setup, (harness) => {
     const context = {
       addSolutionButtonText: 'Add Catalogue Solution',
-      addSolutionButtonHref: '#',
+      addSolutionButtonHref: '/organistaions/order-1/catalogue-solutions/select',
     };
 
     harness.request(context, ($) => {
@@ -88,7 +88,7 @@ describe('catalogue-solutions page', () => {
       expect(addSolutionButton.length).toEqual(1);
       expect(addSolutionButton.find('a').hasClass('nhsuk-button--secondary')).toEqual(true);
       expect(addSolutionButton.text().trim()).toEqual(context.addSolutionButtonText);
-      expect(addSolutionButton.find('a').attr('href')).toEqual('#');
+      expect(addSolutionButton.find('a').attr('href')).toEqual(context.addSolutionButtonHref);
     });
   }));
 

--- a/app/pages/sections/catalogue-solutions/catalogue-solutions/ui-tests/general.ui.test.js
+++ b/app/pages/sections/catalogue-solutions/catalogue-solutions/ui-tests/general.ui.test.js
@@ -131,7 +131,7 @@ test('should render the Add Catalogue Solution button', async (t) => {
     .expect(await extractInnerText(addSolutionButton)).eql(content.addSolutionButtonText);
 });
 
-test('should navigate to /organisation/order-id/catalogue-solutions/select with clicking the Add Catalogue Solution button', async (t) => {
+test('should navigate to /organisation/order-id/catalogue-solutions/select when Add Catalogue Solution button is clicked', async (t) => {
   await pageSetup(t, true);
   await t.navigateTo(pageUrl);
 

--- a/app/pages/sections/catalogue-solutions/catalogue-solutions/ui-tests/general.ui.test.js
+++ b/app/pages/sections/catalogue-solutions/catalogue-solutions/ui-tests/general.ui.test.js
@@ -131,6 +131,17 @@ test('should render the Add Catalogue Solution button', async (t) => {
     .expect(await extractInnerText(addSolutionButton)).eql(content.addSolutionButtonText);
 });
 
+test('should navigate to /organisation/order-id/catalogue-solutions/select with clicking the Add Catalogue Solution button', async (t) => {
+  await pageSetup(t, true);
+  await t.navigateTo(pageUrl);
+
+  const addSolutionButton = Selector('[data-test-id="add-solution-button"] a');
+
+  await t
+    .click(addSolutionButton)
+    .expect(getLocation()).eql('http://localhost:1234/order/organisation/order-id/catalogue-solutions/select');
+});
+
 test('should render the Continue button', async (t) => {
   await pageSetup(t, true);
   await t.navigateTo(pageUrl);

--- a/app/pages/sections/catalogue-solutions/routes.js
+++ b/app/pages/sections/catalogue-solutions/routes.js
@@ -33,5 +33,12 @@ export const catalogueSolutionsRoutes = (authProvider, addContext) => {
     return res.redirect(`${config.baseUrl}/organisation/${orderId}`);
   }));
 
+  router.get('/select', authProvider.authorise({ claim: 'ordering' }), withCatch(authProvider, async (req, res) => {
+    const { orderId } = req.params;
+
+    logger.info(`navigating to order ${orderId} catalogue-solutions select solution page`);
+    return res.send('select solution page');
+  }));
+
   return router;
 };

--- a/app/pages/sections/catalogue-solutions/routes.test.js
+++ b/app/pages/sections/catalogue-solutions/routes.test.js
@@ -59,7 +59,7 @@ describe('catalogue-solutions section routes', () => {
       })
     ));
 
-    it('should return the catalogue-solutions text if authorised', () => {
+    it('should return the catalogue-solutions page if authorised', () => {
       catalogueSolutionsController.getCatalogueSolutionsPageContext = jest.fn()
         .mockResolvedValue({});
 
@@ -138,6 +138,40 @@ describe('catalogue-solutions section routes', () => {
           expect(res.redirect).toEqual(true);
           expect(res.headers.location).toEqual(`${baseUrl}/organisation/order-id`);
           expect(res.text.includes('data-test-id="error-title"')).toEqual(false);
+        });
+    });
+  });
+
+  describe('GET /organisation/:orderId/catalogue-solutions/select', () => {
+    const path = '/organisation/some-order-id/catalogue-solutions/select';
+
+    it('should redirect to the login page if the user is not logged in', () => (
+      testAuthorisedGetPathForUnauthenticatedUser({
+        app: request(setUpFakeApp()), getPath: path, expectedRedirectPath: 'http://identity-server/login',
+      })
+    ));
+
+    it('should show the error page indicating the user is not authorised if the user is logged in but not authorised', () => (
+      testAuthorisedGetPathForUnauthorisedUser({
+        app: request(setUpFakeApp()),
+        getPath: path,
+        getPathCookies: [mockUnauthorisedCookie],
+        expectedPageId: 'data-test-id="error-title"',
+        expectedPageMessage: 'You are not authorised to view this page',
+      })
+    ));
+
+    it('should return the catalogue-solutions select text if authorised', () => {
+      catalogueSolutionsController.getCatalogueSolutionsPageContext = jest.fn()
+        .mockResolvedValue({});
+
+      return request(setUpFakeApp())
+        .get(path)
+        .set('Cookie', [mockAuthorisedCookie])
+        .expect(200)
+        .then((res) => {
+          expect(res.text.includes('select solution page')).toBeTruthy();
+          expect(res.text.includes('data-test-id="error-title"')).toBeFalsy();
         });
     });
   });

--- a/app/pages/sections/commencement-date/ui-tests/general.ui.test.js
+++ b/app/pages/sections/commencement-date/ui-tests/general.ui.test.js
@@ -14,16 +14,15 @@ const setCookies = ClientFunction(() => {
   document.cookie = `fakeToken=${cookieValue}`;
 });
 
-
-const mocks = (mockData) => {
+const mocks = () => {
   nock(orderApiUrl)
     .get('/api/v1/orders/order-id/sections/commencement-date')
-    .reply(200, mockData);
+    .reply(200, {});
 };
 
-const pageSetup = async (t, withAuth = false, mockData = {}) => {
+const pageSetup = async (t, withAuth = false) => {
   if (withAuth) {
-    mocks(mockData);
+    mocks();
     await setCookies();
   }
 };
@@ -37,7 +36,7 @@ const putCommencementDateErrorResponse = {
   }],
 };
 
-fixture('commencement-date page')
+fixture('commencement-date page - general')
   .page('http://localhost:1234/some-fake-page')
   .afterEach(async (t) => {
     const isDone = nock.isDone();
@@ -169,24 +168,6 @@ test('should render input fields for day, month and year', async (t) => {
     .expect(yearInput.getAttribute('type')).eql('number');
 });
 
-test('should populate input fields for day, month and year if data is returned from api', async (t) => {
-  await pageSetup(t, true, { commencementDate: '2020-02-01T00:00:00' });
-  await t.navigateTo(pageUrl);
-
-  const inputFields = Selector('#commencementDate input:not([name=_csrf])');
-  const dayInput = inputFields.nth(0);
-  const monthInput = inputFields.nth(1);
-  const yearInput = inputFields.nth(2);
-
-  await t
-    .expect(dayInput.exists).ok()
-    .expect(dayInput.getAttribute('value')).eql('01')
-    .expect(monthInput.exists).ok()
-    .expect(monthInput.getAttribute('value')).eql('02')
-    .expect(yearInput.exists).ok()
-    .expect(yearInput.getAttribute('value')).eql('2020');
-});
-
 test('should render save button', async (t) => {
   await pageSetup(t, true);
   await t.navigateTo(pageUrl);
@@ -198,7 +179,6 @@ test('should render save button', async (t) => {
     .expect(await extractInnerText(button)).eql(content.saveButtonText);
 });
 
-// FE Validation tests
 test('should navigate to task list page if save button is clicked and data is valid', async (t) => {
   nock(orderApiUrl)
     .put('/api/v1/orders/order-id/sections/commencement-date')
@@ -214,13 +194,14 @@ test('should navigate to task list page if save button is clicked and data is va
   const yearInput = inputFields.nth(2);
 
   await t
-    .typeText(dayInput, '01')
-    .typeText(monthInput, '01')
-    .typeText(yearInput, '2020')
+    .typeText(dayInput, '01', { paste: true })
+    .typeText(monthInput, '01', { paste: true })
+    .typeText(yearInput, '2020', { paste: true })
     .click(saveButton)
     .expect(getLocation()).eql('http://localhost:1234/order/organisation/order-id');
 });
 
+// FE Validation tests
 test('should show the correct error summary and input error when no date is entered and save is clicked', async (t) => {
   await pageSetup(t, true);
   await t.navigateTo(pageUrl);
@@ -265,9 +246,9 @@ test('should show the correct error summary and input error when no day is enter
   await t
     .expect(errorMessage.exists).notOk()
     .expect(dayInput.hasClass('nhsuk-input--error')).notOk()
-    .typeText(monthInput, '02')
+    .typeText(monthInput, '02', { paste: true })
     .expect(monthInput.hasClass('nhsuk-input--error')).notOk()
-    .typeText(yearInput, '2020')
+    .typeText(yearInput, '2020', { paste: true })
     .expect(yearInput.hasClass('nhsuk-input--error')).notOk()
     .click(saveButton);
 
@@ -300,10 +281,10 @@ test('should show the correct error summary and input error when no month is ent
 
   await t
     .expect(errorMessage.exists).notOk()
-    .typeText(dayInput, '02')
+    .typeText(dayInput, '02', { paste: true })
     .expect(dayInput.hasClass('nhsuk-input--error')).notOk()
     .expect(monthInput.hasClass('nhsuk-input--error')).notOk()
-    .typeText(yearInput, '2020')
+    .typeText(yearInput, '2020', { paste: true })
     .expect(yearInput.hasClass('nhsuk-input--error')).notOk()
     .click(saveButton);
 
@@ -336,9 +317,9 @@ test('should show the correct error summary and input error when no year is ente
 
   await t
     .expect(errorMessage.exists).notOk()
-    .typeText(dayInput, '02')
+    .typeText(dayInput, '02', { paste: true })
     .expect(dayInput.hasClass('nhsuk-input--error')).notOk()
-    .typeText(monthInput, '02')
+    .typeText(monthInput, '02', { paste: true })
     .expect(monthInput.hasClass('nhsuk-input--error')).notOk()
     .expect(yearInput.hasClass('nhsuk-input--error')).notOk()
     .click(saveButton);
@@ -372,11 +353,11 @@ test('should show the correct error summary and input error when a year > 4 char
 
   await t
     .expect(errorMessage.exists).notOk()
-    .typeText(dayInput, '02')
+    .typeText(dayInput, '02', { paste: true })
     .expect(dayInput.hasClass('nhsuk-input--error')).notOk()
-    .typeText(monthInput, '02')
+    .typeText(monthInput, '02', { paste: true })
     .expect(monthInput.hasClass('nhsuk-input--error')).notOk()
-    .typeText(yearInput, '202020')
+    .typeText(yearInput, '202020', { paste: true })
     .expect(yearInput.hasClass('nhsuk-input--error')).notOk()
     .click(saveButton);
 
@@ -410,11 +391,11 @@ test('should show the correct error summary and input error when a year < 4 char
 
   await t
     .expect(errorMessage.exists).notOk()
-    .typeText(dayInput, '02')
+    .typeText(dayInput, '02', { paste: true })
     .expect(dayInput.hasClass('nhsuk-input--error')).notOk()
-    .typeText(monthInput, '02')
+    .typeText(monthInput, '02', { paste: true })
     .expect(monthInput.hasClass('nhsuk-input--error')).notOk()
-    .typeText(yearInput, '20')
+    .typeText(yearInput, '20', { paste: true })
     .expect(yearInput.hasClass('nhsuk-input--error')).notOk()
     .click(saveButton);
 
@@ -448,11 +429,11 @@ test('should show the correct error summary and input error when a day > 31 is e
 
   await t
     .expect(errorMessage.exists).notOk()
-    .typeText(dayInput, '32')
+    .typeText(dayInput, '32', { paste: true })
     .expect(dayInput.hasClass('nhsuk-input--error')).notOk()
-    .typeText(monthInput, '02')
+    .typeText(monthInput, '02', { paste: true })
     .expect(monthInput.hasClass('nhsuk-input--error')).notOk()
-    .typeText(yearInput, '2020')
+    .typeText(yearInput, '2020', { paste: true })
     .expect(yearInput.hasClass('nhsuk-input--error')).notOk()
     .click(saveButton);
 
@@ -486,11 +467,11 @@ test('should show the correct error summary and input error when a month > 12 is
 
   await t
     .expect(errorMessage.exists).notOk()
-    .typeText(dayInput, '02')
+    .typeText(dayInput, '02', { paste: true })
     .expect(dayInput.hasClass('nhsuk-input--error')).notOk()
-    .typeText(monthInput, '13')
+    .typeText(monthInput, '13', { paste: true })
     .expect(monthInput.hasClass('nhsuk-input--error')).notOk()
-    .typeText(yearInput, '2020')
+    .typeText(yearInput, '2020', { paste: true })
     .expect(yearInput.hasClass('nhsuk-input--error')).notOk()
     .click(saveButton);
 
@@ -524,11 +505,11 @@ test('should show the correct error summary and input error when a year < 1000 i
 
   await t
     .expect(errorMessage.exists).notOk()
-    .typeText(dayInput, '02')
+    .typeText(dayInput, '02', { paste: true })
     .expect(dayInput.hasClass('nhsuk-input--error')).notOk()
-    .typeText(monthInput, '02')
+    .typeText(monthInput, '02', { paste: true })
     .expect(monthInput.hasClass('nhsuk-input--error')).notOk()
-    .typeText(yearInput, '0999')
+    .typeText(yearInput, '0999', { paste: true })
     .expect(yearInput.hasClass('nhsuk-input--error')).notOk()
     .click(saveButton);
 
@@ -562,11 +543,11 @@ test('should show the correct error summary and input error when incorrect day/m
 
   await t
     .expect(errorMessage.exists).notOk()
-    .typeText(dayInput, '31')
+    .typeText(dayInput, '31', { paste: true })
     .expect(dayInput.hasClass('nhsuk-input--error')).notOk()
-    .typeText(monthInput, '02')
+    .typeText(monthInput, '02', { paste: true })
     .expect(monthInput.hasClass('nhsuk-input--error')).notOk()
-    .typeText(yearInput, '2020')
+    .typeText(yearInput, '2020', { paste: true })
     .expect(yearInput.hasClass('nhsuk-input--error')).notOk()
     .click(saveButton);
 
@@ -605,11 +586,11 @@ test('should show text fields as errors with error message when there are BE val
 
   await t
     .expect(errorMessage.exists).notOk()
-    .typeText(dayInput, '01')
+    .typeText(dayInput, '01', { paste: true })
     .expect(dayInput.hasClass('nhsuk-input--error')).notOk()
-    .typeText(monthInput, '01')
+    .typeText(monthInput, '01', { paste: true })
     .expect(monthInput.hasClass('nhsuk-input--error')).notOk()
-    .typeText(yearInput, '2000')
+    .typeText(yearInput, '2000', { paste: true })
     .expect(yearInput.hasClass('nhsuk-input--error')).notOk()
     .click(saveButton);
 
@@ -647,9 +628,9 @@ test('should anchor to the field when clicking on the error link in errorSummary
 
   await t
     .expect(errorMessage.exists).notOk()
-    .typeText(dayInput, '01')
-    .typeText(monthInput, '01')
-    .typeText(yearInput, '2000')
+    .typeText(dayInput, '01', { paste: true })
+    .typeText(monthInput, '01', { paste: true })
+    .typeText(yearInput, '2000', { paste: true })
     .click(saveButton);
 
   await t

--- a/app/pages/sections/commencement-date/ui-tests/withSavedData.ui.test.js
+++ b/app/pages/sections/commencement-date/ui-tests/withSavedData.ui.test.js
@@ -1,0 +1,501 @@
+import nock from 'nock';
+import { ClientFunction, Selector } from 'testcafe';
+import { extractInnerText } from 'buying-catalogue-library';
+import { orderApiUrl } from '../../../../config';
+
+const pageUrl = 'http://localhost:1234/organisation/order-id/commencement-date';
+
+const setCookies = ClientFunction(() => {
+  const cookieValue = JSON.stringify({
+    id: '88421113', name: 'Cool Dude', ordering: 'manage', primaryOrganisationId: 'org-id',
+  });
+
+  document.cookie = `fakeToken=${cookieValue}`;
+});
+
+const mocks = () => {
+  nock(orderApiUrl)
+    .get('/api/v1/orders/order-id/sections/commencement-date')
+    .reply(200, { commencementDate: '2020-02-01T00:00:00' });
+};
+
+const pageSetup = async (t, withAuth = false) => {
+  if (withAuth) {
+    mocks();
+    await setCookies();
+  }
+};
+
+const getLocation = ClientFunction(() => document.location.href);
+
+const putCommencementDateErrorResponse = {
+  errors: [{
+    field: 'CommencementDate',
+    id: 'CommencementDateGreaterThan',
+  }],
+};
+
+fixture('commencement-date page - with saved data')
+  .page('http://localhost:1234/some-fake-page')
+  .afterEach(async (t) => {
+    const isDone = nock.isDone();
+    if (!isDone) {
+      // eslint-disable-next-line no-console
+      console.log(`pending mocks: ${nock.pendingMocks()}`);
+      nock.cleanAll();
+    }
+
+    await t.expect(isDone).ok('Not all nock interceptors were used!');
+  });
+
+test('should populate input fields for day, month and year if data is returned from api', async (t) => {
+  await pageSetup(t, true);
+  await t.navigateTo(pageUrl);
+
+  const inputFields = Selector('#commencementDate input:not([name=_csrf])');
+  const dayInput = inputFields.nth(0);
+  const monthInput = inputFields.nth(1);
+  const yearInput = inputFields.nth(2);
+
+  await t
+    .expect(dayInput.exists).ok()
+    .expect(dayInput.getAttribute('value')).eql('01')
+    .expect(monthInput.exists).ok()
+    .expect(monthInput.getAttribute('value')).eql('02')
+    .expect(yearInput.exists).ok()
+    .expect(yearInput.getAttribute('value')).eql('2020');
+});
+
+test('should navigate to task list page if save button is clicked and data is valid', async (t) => {
+  nock(orderApiUrl)
+    .put('/api/v1/orders/order-id/sections/commencement-date')
+    .reply(200, {});
+
+  await pageSetup(t, true);
+  await t.navigateTo(pageUrl);
+
+  const saveButton = Selector('[data-test-id="save-button"] button');
+
+  await t
+    .click(saveButton)
+    .expect(getLocation()).eql('http://localhost:1234/order/organisation/order-id');
+});
+
+// FE Validation tests
+test('should show the correct error summary and input error when date is removed and save is clicked', async (t) => {
+  await pageSetup(t, true);
+  await t.navigateTo(pageUrl);
+
+  const saveButton = Selector('[data-test-id="save-button"] button');
+  const errorSummary = Selector('[data-test-id="error-summary"]');
+  const errorMessage = Selector('#commencementDate-error span');
+  const dayInput = Selector('#commencementDate-day');
+  const monthInput = Selector('#commencementDate-month');
+  const yearInput = Selector('#commencementDate-year');
+
+  await t
+    .debug()
+    .expect(errorMessage.exists).notOk()
+    .expect(dayInput.hasClass('nhsuk-input--error')).notOk()
+    .selectText(dayInput).pressKey('delete')
+    .expect(monthInput.hasClass('nhsuk-input--error')).notOk()
+    .selectText(monthInput).pressKey('delete')
+    .expect(yearInput.hasClass('nhsuk-input--error')).notOk()
+    .selectText(yearInput).pressKey('delete')
+    .click(saveButton);
+
+  await t
+    .expect(errorSummary.exists).ok()
+    .expect(errorSummary.find('li a').count).eql(1)
+    .expect(await extractInnerText(errorSummary.find('li a').nth(0))).eql('Enter a commencement date')
+    .expect(errorMessage.exists).ok()
+    .expect(await extractInnerText(errorMessage)).eql('Error:')
+
+    .expect(dayInput.hasClass('nhsuk-input--error')).ok()
+    .expect(monthInput.hasClass('nhsuk-input--error')).ok()
+    .expect(yearInput.hasClass('nhsuk-input--error')).ok();
+});
+
+test('should show the correct error summary and input error when no day is removed and save is clicked', async (t) => {
+  await pageSetup(t, true);
+  await t.navigateTo(pageUrl);
+
+  const saveButton = Selector('[data-test-id="save-button"] button');
+  const errorSummary = Selector('[data-test-id="error-summary"]');
+  const errorMessage = Selector('#commencementDate-error span');
+  const dayInput = Selector('#commencementDate-day');
+  const monthInput = Selector('#commencementDate-month');
+  const yearInput = Selector('#commencementDate-year');
+
+  await t
+    .expect(errorMessage.exists).notOk()
+    .expect(dayInput.hasClass('nhsuk-input--error')).notOk()
+    .selectText(dayInput).pressKey('delete')
+    .expect(monthInput.hasClass('nhsuk-input--error')).notOk()
+    .expect(yearInput.hasClass('nhsuk-input--error')).notOk()
+    .click(saveButton);
+
+  await t
+    .expect(errorSummary.exists).ok()
+    .expect(errorSummary.find('li a').count).eql(1)
+    .expect(await extractInnerText(errorSummary.find('li a').nth(0))).eql('Commencement date must include a day')
+    .expect(errorMessage.exists).ok()
+    .expect(await extractInnerText(errorMessage)).eql('Error:')
+
+    .expect(dayInput.hasClass('nhsuk-input--error')).ok()
+
+    .expect(monthInput.getAttribute('value')).eql('02')
+    .expect(monthInput.hasClass('nhsuk-input--error')).notOk()
+
+    .expect(yearInput.getAttribute('value')).eql('2020')
+    .expect(yearInput.hasClass('nhsuk-input--error')).notOk();
+});
+
+test('should show the correct error summary and input error when no month is removed and save is clicked', async (t) => {
+  await pageSetup(t, true);
+  await t.navigateTo(pageUrl);
+
+  const saveButton = Selector('[data-test-id="save-button"] button');
+  const errorSummary = Selector('[data-test-id="error-summary"]');
+  const errorMessage = Selector('#commencementDate-error span');
+  const dayInput = Selector('#commencementDate-day');
+  const monthInput = Selector('#commencementDate-month');
+  const yearInput = Selector('#commencementDate-year');
+
+  await t
+    .expect(errorMessage.exists).notOk()
+    .expect(dayInput.hasClass('nhsuk-input--error')).notOk()
+    .expect(monthInput.hasClass('nhsuk-input--error')).notOk()
+    .selectText(monthInput).pressKey('delete')
+    .expect(yearInput.hasClass('nhsuk-input--error')).notOk()
+    .click(saveButton);
+
+  await t
+    .expect(errorSummary.exists).ok()
+    .expect(errorSummary.find('li a').count).eql(1)
+    .expect(await extractInnerText(errorSummary.find('li a').nth(0))).eql('Commencement date must include a month')
+    .expect(errorMessage.exists).ok()
+    .expect(await extractInnerText(errorMessage)).eql('Error:')
+
+    .expect(dayInput.getAttribute('value')).eql('01')
+    .expect(dayInput.hasClass('nhsuk-input--error')).notOk()
+
+    .expect(monthInput.hasClass('nhsuk-input--error')).ok()
+
+    .expect(yearInput.getAttribute('value')).eql('2020')
+    .expect(yearInput.hasClass('nhsuk-input--error')).notOk();
+});
+
+test('should show the correct error summary and input error when no year is entered and save is clicked', async (t) => {
+  await pageSetup(t, true);
+  await t.navigateTo(pageUrl);
+
+  const saveButton = Selector('[data-test-id="save-button"] button');
+  const errorSummary = Selector('[data-test-id="error-summary"]');
+  const errorMessage = Selector('#commencementDate-error span');
+  const dayInput = Selector('#commencementDate-day');
+  const monthInput = Selector('#commencementDate-month');
+  const yearInput = Selector('#commencementDate-year');
+
+  await t
+    .expect(errorMessage.exists).notOk()
+    .expect(dayInput.hasClass('nhsuk-input--error')).notOk()
+    .expect(monthInput.hasClass('nhsuk-input--error')).notOk()
+    .expect(yearInput.hasClass('nhsuk-input--error')).notOk()
+    .selectText(yearInput).pressKey('delete')
+    .click(saveButton);
+
+  await t
+    .expect(errorSummary.exists).ok()
+    .expect(errorSummary.find('li a').count).eql(1)
+    .expect(await extractInnerText(errorSummary.find('li a').nth(0))).eql('Commencement date must include a year')
+    .expect(errorMessage.exists).ok()
+    .expect(await extractInnerText(errorMessage)).eql('Error:')
+
+    .expect(dayInput.getAttribute('value')).eql('01')
+    .expect(dayInput.hasClass('nhsuk-input--error')).notOk()
+
+    .expect(monthInput.getAttribute('value')).eql('02')
+    .expect(monthInput.hasClass('nhsuk-input--error')).notOk()
+
+    .expect(yearInput.hasClass('nhsuk-input--error')).ok();
+});
+
+test('should show the correct error summary and input error when a year > 4 chars is entered and save is clicked', async (t) => {
+  await pageSetup(t, true);
+  await t.navigateTo(pageUrl);
+
+  const saveButton = Selector('[data-test-id="save-button"] button');
+  const errorSummary = Selector('[data-test-id="error-summary"]');
+  const errorMessage = Selector('#commencementDate-error span');
+  const dayInput = Selector('#commencementDate-day');
+  const monthInput = Selector('#commencementDate-month');
+  const yearInput = Selector('#commencementDate-year');
+
+  await t
+    .debug()
+    .expect(errorMessage.exists).notOk()
+    .expect(dayInput.hasClass('nhsuk-input--error')).notOk()
+    .expect(monthInput.hasClass('nhsuk-input--error')).notOk()
+    .expect(yearInput.hasClass('nhsuk-input--error')).notOk()
+    .selectText(yearInput).pressKey('delete').typeText(yearInput, '202020', { paste: true })
+    .click(saveButton);
+
+  await t
+    .expect(errorSummary.exists).ok()
+    .expect(errorSummary.find('li a').count).eql(1)
+    .expect(await extractInnerText(errorSummary.find('li a').nth(0))).eql('Year must be four numbers')
+    .expect(errorMessage.exists).ok()
+    .expect(await extractInnerText(errorMessage)).eql('Error:')
+
+    .expect(dayInput.getAttribute('value')).eql('01')
+    .expect(dayInput.hasClass('nhsuk-input--error')).notOk()
+
+    .expect(monthInput.getAttribute('value')).eql('02')
+    .expect(monthInput.hasClass('nhsuk-input--error')).notOk()
+
+    .expect(yearInput.getAttribute('value')).eql('202020')
+    .expect(yearInput.hasClass('nhsuk-input--error')).ok();
+});
+
+test('should show the correct error summary and input error when a year < 4 chars is entered and save is clicked', async (t) => {
+  await pageSetup(t, true);
+  await t.navigateTo(pageUrl);
+
+  const saveButton = Selector('[data-test-id="save-button"] button');
+  const errorSummary = Selector('[data-test-id="error-summary"]');
+  const errorMessage = Selector('#commencementDate-error span');
+  const dayInput = Selector('#commencementDate-day');
+  const monthInput = Selector('#commencementDate-month');
+  const yearInput = Selector('#commencementDate-year');
+
+  await t
+    .expect(errorMessage.exists).notOk()
+    .expect(dayInput.hasClass('nhsuk-input--error')).notOk()
+    .expect(monthInput.hasClass('nhsuk-input--error')).notOk()
+    .expect(yearInput.hasClass('nhsuk-input--error')).notOk()
+    .selectText(yearInput).pressKey('delete').typeText(yearInput, '20', { paste: true })
+    .click(saveButton);
+
+  await t
+    .expect(errorSummary.exists).ok()
+    .expect(errorSummary.find('li a').count).eql(1)
+    .expect(await extractInnerText(errorSummary.find('li a').nth(0))).eql('Year must be four numbers')
+    .expect(errorMessage.exists).ok()
+    .expect(await extractInnerText(errorMessage)).eql('Error:')
+
+    .expect(dayInput.getAttribute('value')).eql('01')
+    .expect(dayInput.hasClass('nhsuk-input--error')).notOk()
+
+    .expect(monthInput.getAttribute('value')).eql('02')
+    .expect(monthInput.hasClass('nhsuk-input--error')).notOk()
+
+    .expect(yearInput.getAttribute('value')).eql('20')
+    .expect(yearInput.hasClass('nhsuk-input--error')).ok();
+});
+
+test('should show the correct error summary and input error when a day > 31 is entered and save is clicked', async (t) => {
+  await pageSetup(t, true);
+  await t.navigateTo(pageUrl);
+
+  const saveButton = Selector('[data-test-id="save-button"] button');
+  const errorSummary = Selector('[data-test-id="error-summary"]');
+  const errorMessage = Selector('#commencementDate-error span');
+  const dayInput = Selector('#commencementDate-day');
+  const monthInput = Selector('#commencementDate-month');
+  const yearInput = Selector('#commencementDate-year');
+
+  await t
+    .expect(errorMessage.exists).notOk()
+    .expect(dayInput.hasClass('nhsuk-input--error')).notOk()
+    .selectText(dayInput).pressKey('delete').typeText(dayInput, '32', { paste: true })
+    .expect(monthInput.hasClass('nhsuk-input--error')).notOk()
+    .expect(yearInput.hasClass('nhsuk-input--error')).notOk()
+    .click(saveButton);
+
+  await t
+    .expect(errorSummary.exists).ok()
+    .expect(errorSummary.find('li a').count).eql(1)
+    .expect(await extractInnerText(errorSummary.find('li a').nth(0))).eql('Commencement date must be a real date')
+    .expect(errorMessage.exists).ok()
+    .expect(await extractInnerText(errorMessage)).eql('Error:')
+
+    .expect(dayInput.getAttribute('value')).eql('32')
+    .expect(dayInput.hasClass('nhsuk-input--error')).ok()
+
+    .expect(monthInput.getAttribute('value')).eql('02')
+    .expect(monthInput.hasClass('nhsuk-input--error')).notOk()
+
+    .expect(yearInput.getAttribute('value')).eql('2020')
+    .expect(yearInput.hasClass('nhsuk-input--error')).notOk();
+});
+
+test('should show the correct error summary and input error when a month > 12 is entered and save is clicked', async (t) => {
+  await pageSetup(t, true);
+  await t.navigateTo(pageUrl);
+
+  const saveButton = Selector('[data-test-id="save-button"] button');
+  const errorSummary = Selector('[data-test-id="error-summary"]');
+  const errorMessage = Selector('#commencementDate-error span');
+  const dayInput = Selector('#commencementDate-day');
+  const monthInput = Selector('#commencementDate-month');
+  const yearInput = Selector('#commencementDate-year');
+
+  await t
+    .expect(errorMessage.exists).notOk()
+    .expect(dayInput.hasClass('nhsuk-input--error')).notOk()
+    .expect(monthInput.hasClass('nhsuk-input--error')).notOk()
+    .selectText(monthInput).pressKey('delete').typeText(monthInput, '13', { paste: true })
+    .expect(yearInput.hasClass('nhsuk-input--error')).notOk()
+    .click(saveButton);
+
+  await t
+    .expect(errorSummary.exists).ok()
+    .expect(errorSummary.find('li a').count).eql(1)
+    .expect(await extractInnerText(errorSummary.find('li a').nth(0))).eql('Commencement date must be a real date')
+    .expect(errorMessage.exists).ok()
+    .expect(await extractInnerText(errorMessage)).eql('Error:')
+
+    .expect(dayInput.getAttribute('value')).eql('01')
+    .expect(dayInput.hasClass('nhsuk-input--error')).notOk()
+
+    .expect(monthInput.getAttribute('value')).eql('13')
+    .expect(monthInput.hasClass('nhsuk-input--error')).ok()
+
+    .expect(yearInput.getAttribute('value')).eql('2020')
+    .expect(yearInput.hasClass('nhsuk-input--error')).notOk();
+});
+
+test('should show the correct error summary and input error when a year < 1000 is entered and save is clicked', async (t) => {
+  await pageSetup(t, true);
+  await t.navigateTo(pageUrl);
+
+  const saveButton = Selector('[data-test-id="save-button"] button');
+  const errorSummary = Selector('[data-test-id="error-summary"]');
+  const errorMessage = Selector('#commencementDate-error span');
+  const dayInput = Selector('#commencementDate-day');
+  const monthInput = Selector('#commencementDate-month');
+  const yearInput = Selector('#commencementDate-year');
+
+  await t
+    .expect(errorMessage.exists).notOk()
+    .expect(dayInput.hasClass('nhsuk-input--error')).notOk()
+    .expect(monthInput.hasClass('nhsuk-input--error')).notOk()
+    .expect(yearInput.hasClass('nhsuk-input--error')).notOk()
+    .selectText(yearInput).pressKey('delete').typeText(yearInput, '0999', { paste: true })
+    .click(saveButton);
+
+  await t
+    .expect(errorSummary.exists).ok()
+    .expect(errorSummary.find('li a').count).eql(1)
+    .expect(await extractInnerText(errorSummary.find('li a').nth(0))).eql('Commencement date must be a real date')
+    .expect(errorMessage.exists).ok()
+    .expect(await extractInnerText(errorMessage)).eql('Error:')
+
+    .expect(dayInput.getAttribute('value')).eql('01')
+    .expect(dayInput.hasClass('nhsuk-input--error')).notOk()
+
+    .expect(monthInput.getAttribute('value')).eql('02')
+    .expect(monthInput.hasClass('nhsuk-input--error')).notOk()
+
+    .expect(yearInput.getAttribute('value')).eql('0999')
+    .expect(yearInput.hasClass('nhsuk-input--error')).ok();
+});
+
+test('should show the correct error summary and input error when incorrect day/month combo is entered and save is clicked', async (t) => {
+  await pageSetup(t, true);
+  await t.navigateTo(pageUrl);
+
+  const saveButton = Selector('[data-test-id="save-button"] button');
+  const errorSummary = Selector('[data-test-id="error-summary"]');
+  const errorMessage = Selector('#commencementDate-error span');
+  const dayInput = Selector('#commencementDate-day');
+  const monthInput = Selector('#commencementDate-month');
+  const yearInput = Selector('#commencementDate-year');
+
+  await t
+    .expect(errorMessage.exists).notOk()
+    .expect(dayInput.hasClass('nhsuk-input--error')).notOk()
+    .selectText(dayInput).pressKey('delete').typeText(dayInput, '31', { paste: true })
+    .expect(monthInput.hasClass('nhsuk-input--error')).notOk()
+    .expect(yearInput.hasClass('nhsuk-input--error')).notOk()
+    .click(saveButton);
+
+  await t
+    .expect(errorSummary.exists).ok()
+    .expect(errorSummary.find('li a').count).eql(1)
+    .expect(await extractInnerText(errorSummary.find('li a').nth(0))).eql('Commencement date must be a real date')
+    .expect(errorMessage.exists).ok()
+    .expect(await extractInnerText(errorMessage)).eql('Error:')
+
+    .expect(dayInput.getAttribute('value')).eql('31')
+    .expect(dayInput.hasClass('nhsuk-input--error')).ok()
+
+    .expect(monthInput.getAttribute('value')).eql('02')
+    .expect(monthInput.hasClass('nhsuk-input--error')).ok()
+
+    .expect(yearInput.getAttribute('value')).eql('2020')
+    .expect(yearInput.hasClass('nhsuk-input--error')).notOk();
+});
+
+// BE Validation tests
+test('should show text fields as errors with error message when there are BE validation errors', async (t) => {
+  nock(orderApiUrl)
+    .put('/api/v1/orders/order-id/sections/commencement-date')
+    .reply(400, putCommencementDateErrorResponse);
+
+  await pageSetup(t, true);
+  await t.navigateTo(pageUrl);
+
+  const saveButton = Selector('[data-test-id="save-button"] button');
+  const errorSummary = Selector('[data-test-id="error-summary"]');
+  const errorMessage = Selector('#commencementDate-error span');
+  const dayInput = Selector('#commencementDate-day');
+  const monthInput = Selector('#commencementDate-month');
+  const yearInput = Selector('#commencementDate-year');
+
+  await t
+    .expect(errorMessage.exists).notOk()
+    .expect(dayInput.hasClass('nhsuk-input--error')).notOk()
+    .expect(monthInput.hasClass('nhsuk-input--error')).notOk()
+    .expect(yearInput.hasClass('nhsuk-input--error')).notOk()
+    .click(saveButton);
+
+  await t
+    .expect(errorSummary.exists).ok()
+    .expect(errorSummary.find('li a').count).eql(1)
+    .expect(await extractInnerText(errorSummary.find('li a').nth(0))).eql('Commencement date must be in the future or within the last 60 days')
+    .expect(errorMessage.exists).ok()
+    .expect(await extractInnerText(errorMessage)).eql('Error:')
+
+    .expect(dayInput.getAttribute('value')).eql('01')
+    .expect(dayInput.hasClass('nhsuk-input--error')).ok()
+
+    .expect(monthInput.getAttribute('value')).eql('02')
+    .expect(monthInput.hasClass('nhsuk-input--error')).ok()
+
+    .expect(yearInput.getAttribute('value')).eql('2020')
+    .expect(yearInput.hasClass('nhsuk-input--error')).ok();
+});
+
+test('should anchor to the field when clicking on the error link in errorSummary ', async (t) => {
+  nock(orderApiUrl)
+    .put('/api/v1/orders/order-id/sections/commencement-date')
+    .reply(400, putCommencementDateErrorResponse);
+
+  await pageSetup(t, true);
+  await t.navigateTo(pageUrl);
+
+  const saveButton = Selector('[data-test-id="save-button"] button');
+  const errorSummary = Selector('[data-test-id="error-summary"]');
+  const errorMessage = Selector('#commencementDate-error span');
+
+  await t
+    .expect(errorMessage.exists).notOk()
+    .click(saveButton);
+
+  await t
+    .expect(errorSummary.exists).ok()
+    .click(errorSummary.find('li a').nth(0))
+    .expect(getLocation()).eql(`${pageUrl}#commencementDate`);
+});

--- a/app/pages/sections/commencement-date/ui-tests/withSavedData.ui.test.js
+++ b/app/pages/sections/commencement-date/ui-tests/withSavedData.ui.test.js
@@ -94,7 +94,6 @@ test('should show the correct error summary and input error when date is removed
   const yearInput = Selector('#commencementDate-year');
 
   await t
-    .debug()
     .expect(errorMessage.exists).notOk()
     .expect(dayInput.hasClass('nhsuk-input--error')).notOk()
     .selectText(dayInput).pressKey('delete')
@@ -233,7 +232,6 @@ test('should show the correct error summary and input error when a year > 4 char
   const yearInput = Selector('#commencementDate-year');
 
   await t
-    .debug()
     .expect(errorMessage.exists).notOk()
     .expect(dayInput.hasClass('nhsuk-input--error')).notOk()
     .expect(monthInput.hasClass('nhsuk-input--error')).notOk()


### PR DESCRIPTION
Story [AB#5350](https://buyingcatalog.visualstudio.com/c5f97979-5b03-4d10-ba8d-871d0526b408/_workitems/edit/5350)
Task [AB#7526](https://buyingcatalog.visualstudio.com/c5f97979-5b03-4d10-ba8d-871d0526b408/_workitems/edit/7526)

Include route to the select solution route which can be navigated when the add catalogue solution button is clicked

Also tidy up of commencement date ui.tests includes checking that dates are still populated with saved data when validation error context is triggered