### PR TITLE
Delete a Catalogue Solution

### DIFF
--- a/app/helpers/api/ordapi/deleteCatalogueSolution.js
+++ b/app/helpers/api/ordapi/deleteCatalogueSolution.js
@@ -1,0 +1,16 @@
+import { deleteData } from 'buying-catalogue-library';
+import { logger } from '../../../logger';
+import { orderApiUrl } from '../../../config';
+
+const deleteCatalogueSolutionEndpoint = (orderId, orderItemId) => (
+  `${orderApiUrl}/api/v1/orders/${orderId}/order-items/${orderItemId}`
+);
+
+export const deleteCatalogueSolution = async ({ orderId, orderItemId, accessToken }) => {
+  const endpoint = deleteCatalogueSolutionEndpoint(orderId, orderItemId);
+
+  await deleteData({ endpoint, accessToken, logger });
+
+  logger.info(`Delete catalogue solution ${orderItemId} returned for order ${orderId}`);
+  return { success: true };
+};

--- a/app/helpers/api/ordapi/deleteCatalogueSolution.test.js
+++ b/app/helpers/api/ordapi/deleteCatalogueSolution.test.js
@@ -1,0 +1,60 @@
+import { deleteData } from 'buying-catalogue-library';
+import { deleteCatalogueSolution } from './deleteCatalogueSolution';
+import { orderApiUrl } from '../../../config';
+import { logger } from '../../../logger';
+
+jest.mock('buying-catalogue-library');
+
+describe('deleteCatalogueSolution', () => {
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  describe('with errors', () => {
+    it('should throw an error if api request is unsuccessful', async () => {
+      deleteData.mockRejectedValueOnce({ response: { status: 404 } });
+
+      try {
+        await deleteCatalogueSolution({
+          orderId: 'order1',
+          orderItemId: 'orderItemId1',
+          accessToken: 'access_token',
+        });
+      } catch (err) {
+        expect(err).toEqual({ response: { status: 404 } });
+      }
+    });
+  });
+
+  describe('with no errors', () => {
+    it('should call deleteData with the expected parameters', async () => {
+      deleteData.mockResolvedValueOnce();
+
+      await deleteCatalogueSolution({
+        orderId: 'order1',
+        orderItemId: 'order-Item-Id-1',
+        accessToken: 'access_token',
+      });
+
+      expect(deleteData.mock.calls.length).toEqual(1);
+      expect(deleteData).toHaveBeenCalledWith({
+        endpoint: `${orderApiUrl}/api/v1/orders/order1/order-items/order-Item-Id-1`,
+        accessToken: 'access_token',
+        logger,
+      });
+    });
+
+    it('should return success as true if deleted successfully', async () => {
+      deleteData.mockResolvedValueOnce({ response: { status: 204 } });
+
+      const response = await deleteCatalogueSolution({
+        orderId: 'order1',
+        orderItemId: 'order-Item-Id-1',
+        accessToken: 'access_token',
+      });
+
+      expect(response.success).toEqual(true);
+      expect(response.errors).toEqual(undefined);
+    });
+  });
+});

--- a/app/pages/sections/order-items/catalogue-solutions/delete/controller.js
+++ b/app/pages/sections/order-items/catalogue-solutions/delete/controller.js
@@ -1,0 +1,9 @@
+import { deleteCatalogueSolution as apiDeleteCatalogueSolution } from '../../../../../helpers/api/ordapi/deleteCatalogueSolution';
+
+export const deleteCatalogueSolution = async ({
+  orderId,
+  orderItemId,
+  accessToken,
+}) => {
+  await apiDeleteCatalogueSolution({ orderId, orderItemId, accessToken });
+};

--- a/app/pages/sections/order-items/catalogue-solutions/delete/controller.test.js
+++ b/app/pages/sections/order-items/catalogue-solutions/delete/controller.test.js
@@ -1,0 +1,26 @@
+import { deleteCatalogueSolution as apiDeleteCatalogueSolution } from '../../../../../helpers/api/ordapi/deleteCatalogueSolution';
+import { deleteCatalogueSolution } from './controller';
+
+jest.mock('../../../../../helpers/api/ordapi/deleteCatalogueSolution');
+
+describe('catalogue-solutions delete controller', () => {
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  describe('deleteCatalogueSolution', () => {
+    it('should call deleteCatalogueSolution with the correct params', async () => {
+      apiDeleteCatalogueSolution.mockResolvedValueOnce();
+
+      const orderId = 'order-id';
+      const orderItemId = 'order-item-id';
+      const accessToken = 'access-token';
+
+      await deleteCatalogueSolution({ orderId, orderItemId, accessToken });
+
+      expect(apiDeleteCatalogueSolution.mock.calls.length).toEqual(1);
+      expect(apiDeleteCatalogueSolution)
+        .toHaveBeenCalledWith({ orderId, orderItemId, accessToken });
+    });
+  });
+});

--- a/app/pages/sections/order-items/catalogue-solutions/delete/routes.js
+++ b/app/pages/sections/order-items/catalogue-solutions/delete/routes.js
@@ -1,0 +1,30 @@
+import express from 'express';
+import { logger } from '../../../../../logger';
+import { withCatch, extractAccessToken } from '../../../../../helpers/routes/routerHelper';
+import { deleteCatalogueSolution } from './controller';
+import config from '../../../../../config';
+
+const router = express.Router({ mergeParams: true });
+
+export const deleteCatalogueSolutionsRoutes = (authProvider, addContext) => {
+  router.get('/:orderItemId', authProvider.authorise({ claim: 'ordering' }), withCatch(logger, authProvider, async (req, res) => {
+    const { orderId, orderItemId } = req.params;
+
+    const context = {};
+
+    logger.info(`navigating to order ${orderId} catalogue-solutions ${orderItemId} deletion page`);
+    return res.render('pages/sections/order-items/catalogue-solutions/dashboard/template.njk', addContext({ context, user: req.user, csrfToken: req.csrfToken() }));
+  }));
+
+  router.post('/:orderItemId', authProvider.authorise({ claim: 'ordering' }), withCatch(logger, authProvider, async (req, res) => {
+    const { orderId, orderItemId } = req.params;
+    const accessToken = extractAccessToken({ req, tokenType: 'access' });
+
+    await deleteCatalogueSolution({ orderId, orderItemId, accessToken });
+
+    logger.info(`navigating to order ${orderId} catalogue-solution ${orderItemId} delete confirmation page`);
+    return res.redirect(`${config.baseUrl}/organisation/${orderId}/catalogue-solutions/delete/${orderItemId}/confirmation`);
+  }));
+
+  return router;
+};

--- a/app/pages/sections/order-items/catalogue-solutions/delete/routes.test.js
+++ b/app/pages/sections/order-items/catalogue-solutions/delete/routes.test.js
@@ -1,0 +1,69 @@
+import request from 'supertest';
+import {
+  testPostPathWithoutCsrf,
+  testAuthorisedPostPathForUnauthorisedUsers,
+  getCsrfTokenFromGet,
+} from 'buying-catalogue-library';
+import {
+  mockUnauthorisedCookie,
+  mockAuthorisedCookie,
+  setUpFakeApp,
+} from '../../../../../test-utils/routesTestHelper';
+import { baseUrl } from '../../../../../config';
+import * as deleteCatalogueSolutionController from './controller';
+import { sessionKeys } from '../../../../../helpers/routes/sessionHelper';
+
+const mockGetPageDataCookie = `${sessionKeys.orderItemPageData}=${{ selectedRecipients: [{}] }}`;
+
+describe('catalogue-solutions delete routes', () => {
+  describe('POST /organisation/:orderId/catalogue-solutions/delete/:orderItemId', () => {
+    const path = '/organisation/order-42/catalogue-solutions/delete/order-Item-5';
+
+    afterEach(() => {
+      jest.resetAllMocks();
+    });
+
+    it('should return 403 forbidden if no csrf token is available', async () => {
+      await testPostPathWithoutCsrf({
+        app: request(setUpFakeApp()),
+        postPath: path,
+        postPathCookies: [mockAuthorisedCookie],
+      });
+    });
+
+    it('should show the error page indicating the user is not authorised if the user is logged in but not authorised', () => (
+      testAuthorisedPostPathForUnauthorisedUsers({
+        app: request(setUpFakeApp()),
+        getPath: path,
+        postPath: path,
+        getPathCookies: [mockAuthorisedCookie],
+        postPathCookies: [mockUnauthorisedCookie],
+        expectedPageId: 'data-test-id="error-title"',
+        expectedPageMessage: 'You are not authorised to view this page',
+      })
+    ));
+
+    it('should redirect to catalogue solution deletion confirmation page, if the order is deleted', async () => {
+      deleteCatalogueSolutionController.deleteCatalogueSolution = jest.fn().mockResolvedValueOnce();
+
+      const { cookies, csrfToken } = await getCsrfTokenFromGet({
+        app: request(setUpFakeApp()),
+        getPath: path,
+        getPathCookies: [mockAuthorisedCookie],
+      });
+
+      return request(setUpFakeApp())
+        .post(path)
+        .type('form')
+        .set('Cookie', [cookies, mockAuthorisedCookie, mockGetPageDataCookie])
+        .send({
+          _csrf: csrfToken,
+        })
+        .expect(302)
+        .then((res) => {
+          expect(res.redirect).toEqual(true);
+          expect(res.headers.location).toEqual(`${baseUrl}/organisation/order-42/catalogue-solutions/delete/order-Item-5/confirmation`);
+        });
+    });
+  });
+});

--- a/app/pages/sections/routes.js
+++ b/app/pages/sections/routes.js
@@ -20,6 +20,7 @@ import { getFundingSource } from '../../helpers/api/ordapi/getFundingSource';
 import { putFundingSource } from '../../helpers/api/ordapi/putFundingSource';
 import { putOrderingParty } from '../../helpers/api/ordapi/putOrderingParty';
 import { putCommencementDate } from '../../helpers/api/ordapi/putCommencementDate';
+import { deleteCatalogueSolutionsRoutes } from './order-items/catalogue-solutions/delete/routes';
 
 const router = express.Router({ mergeParams: true });
 
@@ -88,6 +89,8 @@ export const sectionRoutes = (authProvider, addContext, sessionManager) => {
   router.use('/supplier', supplierRoutes(authProvider, addContext, sessionManager));
 
   router.use('/catalogue-solutions', catalogueSolutionsRoutes(authProvider, addContext, sessionManager));
+
+  router.use('/catalogue-solutions/delete', deleteCatalogueSolutionsRoutes(authProvider, addContext));
 
   router.use('/additional-services', additionalServicesRoutes(authProvider, addContext, sessionManager));
 


### PR DESCRIPTION
New route setup with call to delete endpoint
Dummy GET call to allow unit tests for POST to pass.

Story: [AB#9038](https://buyingcatalog.visualstudio.com/c5f97979-5b03-4d10-ba8d-871d0526b408/_workitems/edit/9038)
Task: [AB#12974](https://buyingcatalog.visualstudio.com/c5f97979-5b03-4d10-ba8d-871d0526b408/_workitems/edit/12974)